### PR TITLE
mujoco_demo: extract robot backend interface

### DIFF
--- a/mujoco_demo/README.md
+++ b/mujoco_demo/README.md
@@ -72,8 +72,9 @@ mujoco_demo/
 ├── vln_mujoco/
 │   ├── assets/        # a single MolmoSpaces scene, nothing more
 │   ├── web/           # static single page, no build step
-│   ├── model.py       # scene + TurtleBot MJCF
-│   ├── simulation.py  # kinematics, cameras, wheel visualisation
+│   ├── robots/        # robot backend protocol + TurtleBot implementation
+│   ├── model.py       # scene loading and MuJoCo compilation
+│   ├── simulation.py  # shared runtime, cameras, watchdog, frame capture
 │   ├── mpc.py         # CasADi/IPOPT kinematic MPC
 │   ├── vln_client.py  # VLN WebSocket client
 │   └── server.py      # HTTP/WebSocket and control ownership
@@ -81,6 +82,15 @@ mujoco_demo/
 ├── tests/
 └── run.sh
 ```
+
+The simulation runtime is independent of the bundled TurtleBot embodiment.
+Robot implementations satisfy the `RobotBackend` protocol in
+`vln_mujoco/robots/base.py`: they provide a MuJoCo model and data, consume the
+shared planar velocity command, report pose and velocity, and select the two
+render cameras. The runtime continues to own threading, command timeout,
+rendering, frame timestamps, and the server-facing snapshot. A new embodiment
+therefore does not need to modify the VLN client, MPC, web server, or render
+loop.
 
 Body-frame waypoints returned by VLN are first transformed into the world frame
 using the robot pose at image-capture time, then tracked by the MPC in the

--- a/mujoco_demo/tests/test_model.py
+++ b/mujoco_demo/tests/test_model.py
@@ -1,12 +1,10 @@
 import mujoco
-
-from vln_mujoco.model import CAMERA_NAME, build_model
+from vln_mujoco.robots.turtlebot import CAMERA_NAME, TurtleBotBackend
 
 
 def test_bundled_scene_and_robot_compile() -> None:
-    model = build_model()
+    model = TurtleBotBackend().model
     assert model.nu == 0  # pure kinematics: no actuators by design
     assert model.camera(CAMERA_NAME).id >= 0
     assert model.body("base_link").id >= 0
     assert mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_GEOM, "floor") >= 0
-

--- a/mujoco_demo/tests/test_robot_backend.py
+++ b/mujoco_demo/tests/test_robot_backend.py
@@ -1,0 +1,71 @@
+import time
+
+import pytest
+from vln_mujoco.robots.base import RobotState
+from vln_mujoco.robots.turtlebot import TurtleBotBackend
+from vln_mujoco.simulation import COMMAND_TIMEOUT_S, Simulation
+
+
+class TelemetryTurtleBot(TurtleBotBackend):
+    def state(self) -> RobotState:
+        state = super().state()
+        return RobotState(
+            pose=state.pose,
+            velocity=state.velocity,
+            telemetry={"pose": "backend-pose", "policy_command": {"linear": 0.3}},
+        )
+
+
+def test_turtlebot_backend_integrates_velocity_command() -> None:
+    robot = TurtleBotBackend()
+    start = robot.state()
+
+    for _ in range(20):
+        robot.step((0.4, 0.2))
+
+    state = robot.state()
+    assert state.pose[0] > start.pose[0]
+    assert state.pose[1] > start.pose[1]
+    assert state.pose[3] > start.pose[3]
+    assert state.velocity == pytest.approx((0.4, 0.2))
+
+
+def test_turtlebot_backend_reset_restores_spawn_pose() -> None:
+    robot = TurtleBotBackend()
+    robot.step((0.4, 0.2))
+
+    robot.reset()
+
+    state = robot.state()
+    assert state.pose == pytest.approx((6.5, 13.8, 0.033, 0.0))
+    assert state.velocity == pytest.approx((0.0, 0.0))
+
+
+def test_simulation_owns_command_watchdog_and_robot_identity() -> None:
+    simulation = Simulation(TurtleBotBackend())
+    simulation.set_velocity(0.4, 0.2)
+    simulation._advance(time.monotonic())
+
+    assert simulation.robot_name == "TurtleBot"
+    assert simulation.snapshot()["command"] == pytest.approx(
+        {"linear": 0.4, "angular": 0.2}
+    )
+
+    simulation._command_at = time.monotonic() - COMMAND_TIMEOUT_S - 0.1
+    simulation._advance(time.monotonic())
+
+    assert simulation.snapshot()["command"] == pytest.approx(
+        {"linear": 0.0, "angular": 0.0}
+    )
+
+
+def test_simulation_namespaces_backend_telemetry() -> None:
+    simulation = Simulation(TelemetryTurtleBot())
+
+    snapshot = simulation.snapshot()
+
+    assert isinstance(snapshot["pose"], dict)
+    assert snapshot["backend"] == {
+        "pose": "backend-pose",
+        "policy_command": {"linear": 0.3},
+    }

--- a/mujoco_demo/vln_mujoco/model.py
+++ b/mujoco_demo/vln_mujoco/model.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import math
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
@@ -10,13 +9,9 @@ SCENE_NAME = "val_2"
 SCENE_ID = "procthor-val-2"
 SCENE_DATASET = "MolmoSpaces ProcTHOR 10K val"
 SPAWN = (6.5, 13.8, 0.0)
-CAMERA_NAME = "robot_rgb"
-THIRD_PERSON_CAMERA_NAME = "robot_third_person"
 CAMERA_WIDTH = 480
 CAMERA_HEIGHT = 270
 PHYSICS_DT = 0.005
-WHEEL_RADIUS = 0.033
-WHEEL_TRACK = 0.160
 
 
 def scene_path() -> Path:
@@ -46,57 +41,15 @@ def _absolute_asset_paths(root: ET.Element, source: Path) -> None:
         try:
             resolved.relative_to(asset_root)
         except ValueError as exc:
-            raise RuntimeError(f"scene asset escapes the bundled asset root: {filename}") from exc
+            raise RuntimeError(
+                f"scene asset escapes the bundled asset root: {filename}"
+            ) from exc
         if not resolved.is_file():
             raise FileNotFoundError(f"bundled scene asset is missing: {resolved}")
         element.set("file", str(resolved))
 
 
-def _robot_body() -> ET.Element:
-    body = ET.fromstring(
-        f"""
-        <body name="base_link" pos="{SPAWN[0]} {SPAWN[1]} {WHEEL_RADIUS}">
-          <freejoint name="base_joint" />
-          <inertial pos="0 0 0.055" mass="2.5" diaginertia="0.018 0.018 0.025" />
-          <geom name="base_collision" type="cylinder" size="0.092 0.028" pos="0 0 0.030"
-                rgba="0.08 0.11 0.13 1" friction="0.9 0.02 0.002" />
-          <geom name="lower_plate" type="cylinder" size="0.088 0.010" pos="0 0 0.063"
-                rgba="0.05 0.08 0.09 1" contype="0" conaffinity="0" />
-          <geom name="upper_plate" type="cylinder" size="0.078 0.010" pos="0 0 0.145"
-                rgba="0.08 0.68 0.77 1" contype="0" conaffinity="0" />
-          <geom name="mast" type="cylinder" size="0.010 0.052" pos="-0.020 0 0.105"
-                rgba="0.65 0.72 0.74 1" contype="0" conaffinity="0" />
-          <geom name="lidar" type="cylinder" size="0.042 0.018" pos="0.015 0 0.178"
-                rgba="0.05 0.08 0.09 1" contype="0" conaffinity="0" />
-          <geom name="camera_case" type="box" size="0.022 0.030 0.018" pos="0.067 0 0.162"
-                rgba="0.14 0.18 0.19 1" contype="0" conaffinity="0" />
-          <camera name="{CAMERA_NAME}" mode="fixed" pos="0.090 0 0.165"
-                  xyaxes="0 -1 0 0 0 1" fovy="79.865" />
-          <camera name="{THIRD_PERSON_CAMERA_NAME}" mode="fixed" pos="-0.65 0 0.50"
-                  xyaxes="0 -1 0 0.38 0 0.925" fovy="65" />
-          <body name="left_wheel" pos="0 0.080 0">
-            <joint name="left_wheel_joint" type="hinge" axis="0 1 0" />
-            <geom name="left_wheel_geom" type="cylinder" size="{WHEEL_RADIUS} 0.012"
-                  euler="{math.pi / 2} 0 0" mass="0.08" rgba="0.035 0.045 0.048 1"
-                  friction="2.0 0.01 0.001" solref="0.004 1" />
-          </body>
-          <body name="right_wheel" pos="0 -0.080 0">
-            <joint name="right_wheel_joint" type="hinge" axis="0 1 0" />
-            <geom name="right_wheel_geom" type="cylinder" size="{WHEEL_RADIUS} 0.012"
-                  euler="{math.pi / 2} 0 0" mass="0.08" rgba="0.035 0.045 0.048 1"
-                  friction="2.0 0.01 0.001" solref="0.004 1" />
-          </body>
-          <body name="caster" pos="-0.073 0 -0.018">
-            <geom name="caster_geom" type="sphere" size="0.015" mass="0.025"
-                  rgba="0.32 0.36 0.37 1" friction="0.05 0.001 0.0001" />
-          </body>
-        </body>
-        """
-    )
-    return body
-
-
-def build_model(source: Path | None = None) -> mujoco.MjModel:
+def load_scene_xml(source: Path | None = None) -> ET.Element:
     source = (source or scene_path()).resolve()
     if not source.is_file():
         raise FileNotFoundError(
@@ -121,10 +74,8 @@ def build_model(source: Path | None = None) -> mujoco.MjModel:
         global_visual = ET.SubElement(visual, "global")
     global_visual.set("offwidth", str(CAMERA_WIDTH))
     global_visual.set("offheight", str(CAMERA_HEIGHT))
+    return root
 
-    worldbody = root.find("worldbody")
-    if worldbody is None:
-        raise RuntimeError("MolmoSpaces scene has no worldbody")
-    worldbody.append(_robot_body())
 
+def compile_model(root: ET.Element) -> mujoco.MjModel:
     return mujoco.MjModel.from_xml_string(ET.tostring(root, encoding="unicode"))

--- a/mujoco_demo/vln_mujoco/robots/__init__.py
+++ b/mujoco_demo/vln_mujoco/robots/__init__.py
@@ -1,0 +1,1 @@
+"""Robot backends for the standalone MuJoCo demo."""

--- a/mujoco_demo/vln_mujoco/robots/base.py
+++ b/mujoco_demo/vln_mujoco/robots/base.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol, TypeAlias
+
+import mujoco
+
+Twist2D: TypeAlias = tuple[float, float]
+RobotPose: TypeAlias = tuple[float, float, float, float]
+RenderCamera: TypeAlias = str | mujoco.MjvCamera
+
+
+@dataclass(frozen=True)
+class RobotState:
+    pose: RobotPose
+    velocity: Twist2D
+    telemetry: dict[str, object] = field(default_factory=dict)
+
+
+class RobotBackend(Protocol):
+    name: str
+    camera_name: str
+    model: mujoco.MjModel
+    data: mujoco.MjData
+
+    def reset(self) -> None: ...
+
+    def step(self, command: Twist2D) -> None: ...
+
+    def state(self) -> RobotState: ...
+
+    def third_person_camera(self, camera: mujoco.MjvCamera) -> RenderCamera: ...

--- a/mujoco_demo/vln_mujoco/robots/turtlebot.py
+++ b/mujoco_demo/vln_mujoco/robots/turtlebot.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import math
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import mujoco
+
+from ..model import PHYSICS_DT, SPAWN, compile_model, load_scene_xml
+from .base import RenderCamera, RobotState, Twist2D
+
+CAMERA_NAME = "robot_rgb"
+THIRD_PERSON_CAMERA_NAME = "robot_third_person"
+WHEEL_RADIUS = 0.033
+WHEEL_TRACK = 0.160
+
+
+def _robot_body() -> ET.Element:
+    return ET.fromstring(
+        f"""
+        <body name="base_link" pos="{SPAWN[0]} {SPAWN[1]} {WHEEL_RADIUS}">
+          <freejoint name="base_joint" />
+          <inertial pos="0 0 0.055" mass="2.5" diaginertia="0.018 0.018 0.025" />
+          <geom name="base_collision" type="cylinder" size="0.092 0.028" pos="0 0 0.030"
+                rgba="0.08 0.11 0.13 1" friction="0.9 0.02 0.002" />
+          <geom name="lower_plate" type="cylinder" size="0.088 0.010" pos="0 0 0.063"
+                rgba="0.05 0.08 0.09 1" contype="0" conaffinity="0" />
+          <geom name="upper_plate" type="cylinder" size="0.078 0.010" pos="0 0 0.145"
+                rgba="0.08 0.68 0.77 1" contype="0" conaffinity="0" />
+          <geom name="mast" type="cylinder" size="0.010 0.052" pos="-0.020 0 0.105"
+                rgba="0.65 0.72 0.74 1" contype="0" conaffinity="0" />
+          <geom name="lidar" type="cylinder" size="0.042 0.018" pos="0.015 0 0.178"
+                rgba="0.05 0.08 0.09 1" contype="0" conaffinity="0" />
+          <geom name="camera_case" type="box" size="0.022 0.030 0.018" pos="0.067 0 0.162"
+                rgba="0.14 0.18 0.19 1" contype="0" conaffinity="0" />
+          <camera name="{CAMERA_NAME}" mode="fixed" pos="0.090 0 0.165"
+                  xyaxes="0 -1 0 0 0 1" fovy="79.865" />
+          <camera name="{THIRD_PERSON_CAMERA_NAME}" mode="fixed" pos="-0.65 0 0.50"
+                  xyaxes="0 -1 0 0.38 0 0.925" fovy="65" />
+          <body name="left_wheel" pos="0 0.080 0">
+            <joint name="left_wheel_joint" type="hinge" axis="0 1 0" />
+            <geom name="left_wheel_geom" type="cylinder" size="{WHEEL_RADIUS} 0.012"
+                  euler="{math.pi / 2} 0 0" mass="0.08" rgba="0.035 0.045 0.048 1"
+                  friction="2.0 0.01 0.001" solref="0.004 1" />
+          </body>
+          <body name="right_wheel" pos="0 -0.080 0">
+            <joint name="right_wheel_joint" type="hinge" axis="0 1 0" />
+            <geom name="right_wheel_geom" type="cylinder" size="{WHEEL_RADIUS} 0.012"
+                  euler="{math.pi / 2} 0 0" mass="0.08" rgba="0.035 0.045 0.048 1"
+                  friction="2.0 0.01 0.001" solref="0.004 1" />
+          </body>
+          <body name="caster" pos="-0.073 0 -0.018">
+            <geom name="caster_geom" type="sphere" size="0.015" mass="0.025"
+                  rgba="0.32 0.36 0.37 1" friction="0.05 0.001 0.0001" />
+          </body>
+        </body>
+        """
+    )
+
+
+def build_model(source: Path | None = None) -> mujoco.MjModel:
+    root = load_scene_xml(source)
+    worldbody = root.find("worldbody")
+    if worldbody is None:
+        raise RuntimeError("MolmoSpaces scene has no worldbody")
+    worldbody.append(_robot_body())
+    return compile_model(root)
+
+
+class TurtleBotBackend:
+    name = "TurtleBot"
+    camera_name = CAMERA_NAME
+
+    def __init__(self, source: Path | None = None) -> None:
+        self.model = build_model(source)
+        self.data = mujoco.MjData(self.model)
+        self._left_joint = self.model.joint("left_wheel_joint").id
+        self._right_joint = self.model.joint("right_wheel_joint").id
+        self._base_joint = self.model.joint("base_joint").id
+        self._base_qpos = self.model.jnt_qposadr[self._base_joint]
+        self._base_dof = self.model.jnt_dofadr[self._base_joint]
+        self._left_qpos = self.model.jnt_qposadr[self._left_joint]
+        self._right_qpos = self.model.jnt_qposadr[self._right_joint]
+        self._left_dof = self.model.jnt_dofadr[self._left_joint]
+        self._right_dof = self.model.jnt_dofadr[self._right_joint]
+        self._yaw = 0.0
+        mujoco.mj_forward(self.model, self.data)
+
+    def reset(self) -> None:
+        mujoco.mj_resetData(self.model, self.data)
+        self._yaw = 0.0
+        mujoco.mj_forward(self.model, self.data)
+
+    def step(self, command: Twist2D) -> None:
+        linear, angular = command
+        previous_yaw = self._yaw
+        self._yaw = math.atan2(
+            math.sin(previous_yaw + angular * PHYSICS_DT),
+            math.cos(previous_yaw + angular * PHYSICS_DT),
+        )
+        heading = previous_yaw + angular * PHYSICS_DT / 2.0
+        self.data.qpos[self._base_qpos] += linear * math.cos(heading) * PHYSICS_DT
+        self.data.qpos[self._base_qpos + 1] += linear * math.sin(heading) * PHYSICS_DT
+        self.data.qpos[self._base_qpos + 3 : self._base_qpos + 7] = (
+            math.cos(self._yaw / 2.0),
+            0.0,
+            0.0,
+            math.sin(self._yaw / 2.0),
+        )
+
+        left = (linear - angular * WHEEL_TRACK / 2.0) / WHEEL_RADIUS
+        right = (linear + angular * WHEEL_TRACK / 2.0) / WHEEL_RADIUS
+        self.data.qpos[self._left_qpos] += left * PHYSICS_DT
+        self.data.qpos[self._right_qpos] += right * PHYSICS_DT
+        self.data.qvel.fill(0.0)
+        self.data.qvel[self._base_dof] = linear * math.cos(self._yaw)
+        self.data.qvel[self._base_dof + 1] = linear * math.sin(self._yaw)
+        self.data.qvel[self._base_dof + 5] = angular
+        self.data.qvel[self._left_dof] = left
+        self.data.qvel[self._right_dof] = right
+        self.data.time += PHYSICS_DT
+        mujoco.mj_forward(self.model, self.data)
+
+    def state(self) -> RobotState:
+        qpos = self.data.qpos
+        x, y, z = (
+            float(value)
+            for value in qpos[self._base_qpos : self._base_qpos + 3]
+        )
+        qw, qx, qy, qz = (
+            float(value)
+            for value in qpos[self._base_qpos + 3 : self._base_qpos + 7]
+        )
+        yaw = math.atan2(
+            2.0 * (qw * qz + qx * qy),
+            1.0 - 2.0 * (qy * qy + qz * qz),
+        )
+        left = float(self.data.qvel[self._left_dof])
+        right = float(self.data.qvel[self._right_dof])
+        linear = WHEEL_RADIUS * (left + right) / 2.0
+        angular = WHEEL_RADIUS * (right - left) / WHEEL_TRACK
+        return RobotState((x, y, z, yaw), (linear, angular))
+
+    def third_person_camera(self, _camera: mujoco.MjvCamera) -> RenderCamera:
+        return THIRD_PERSON_CAMERA_NAME

--- a/mujoco_demo/vln_mujoco/server.py
+++ b/mujoco_demo/vln_mujoco/server.py
@@ -10,6 +10,7 @@ from urllib.parse import urlparse
 
 from aiohttp import WSMsgType, web
 
+from .model import SCENE_DATASET, SCENE_ID, SCENE_NAME
 from .mpc import (
     A_MAX_V,
     A_MAX_W,
@@ -22,11 +23,10 @@ from .mpc import (
     Q_WEIGHTS,
     R_WEIGHTS,
     TRACK_V_MAX,
-    WAYPOINT_DT_S,
     W_MAX,
+    WAYPOINT_DT_S,
     MpcTracker,
 )
-from .model import SCENE_DATASET, SCENE_ID, SCENE_NAME
 from .simulation import Simulation
 from .vln_client import VlnClient
 
@@ -254,7 +254,7 @@ class VlnMujocoServer:
         )
         return {
             "scene": {"id": SCENE_ID, "name": SCENE_NAME, "dataset": SCENE_DATASET},
-            "robot": {"name": "TurtleBot", "connected": True},
+            "robot": {"name": self.simulation.robot_name, "connected": True},
             "simulation": self.simulation.snapshot(),
             "vln": {
                 "state": vln.state,

--- a/mujoco_demo/vln_mujoco/simulation.py
+++ b/mujoco_demo/vln_mujoco/simulation.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import io
-import math
 import threading
 import time
 from dataclasses import dataclass
@@ -10,17 +9,13 @@ import mujoco
 import numpy as np
 from PIL import Image
 
+from .model import CAMERA_HEIGHT, CAMERA_WIDTH, PHYSICS_DT
 from .mpc import TRACK_V_MAX, W_MAX
-from .model import (
-    CAMERA_HEIGHT,
-    CAMERA_NAME,
-    CAMERA_WIDTH,
-    PHYSICS_DT,
-    THIRD_PERSON_CAMERA_NAME,
-    WHEEL_RADIUS,
-    WHEEL_TRACK,
-    build_model,
-)
+from .robots.base import RobotBackend
+from .robots.turtlebot import TurtleBotBackend
+
+COMMAND_TIMEOUT_S = 0.35
+FRAME_PERIOD_S = 0.05
 
 
 @dataclass(frozen=True)
@@ -32,19 +27,10 @@ class CameraFrame:
 
 
 class Simulation:
-    def __init__(self) -> None:
-        self.model = build_model()
-        self.data = mujoco.MjData(self.model)
-        self._left_joint = self.model.joint("left_wheel_joint").id
-        self._right_joint = self.model.joint("right_wheel_joint").id
-        self._base_joint = self.model.joint("base_joint").id
-        self._base_qpos = self.model.jnt_qposadr[self._base_joint]
-        self._base_dof = self.model.jnt_dofadr[self._base_joint]
-        self._left_qpos = self.model.jnt_qposadr[self._left_joint]
-        self._right_qpos = self.model.jnt_qposadr[self._right_joint]
-        self._left_dof = self.model.jnt_dofadr[self._left_joint]
-        self._right_dof = self.model.jnt_dofadr[self._right_joint]
-        self._yaw = 0.0
+    def __init__(self, robot: RobotBackend | None = None) -> None:
+        self.robot = robot or TurtleBotBackend()
+        self.model = self.robot.model
+        self.data = self.robot.data
         self._lock = threading.RLock()
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
@@ -54,7 +40,10 @@ class Simulation:
         self._third_person_frame: CameraFrame | None = None
         self._frame_count = 0
         self._started_at = time.monotonic()
-        mujoco.mj_forward(self.model, self.data)
+
+    @property
+    def robot_name(self) -> str:
+        return self.robot.name
 
     def start(self) -> None:
         if self._thread is not None:
@@ -72,11 +61,9 @@ class Simulation:
 
     def reset(self) -> None:
         with self._lock:
-            mujoco.mj_resetData(self.model, self.data)
+            self.robot.reset()
             self._command = (0.0, 0.0)
             self._command_at = 0.0
-            self._yaw = 0.0
-            mujoco.mj_forward(self.model, self.data)
 
     def set_velocity(self, linear: float, angular: float) -> None:
         # Physical sanity bound only; per-mode VLN limits live in the MPC.
@@ -106,24 +93,13 @@ class Simulation:
 
     def snapshot(self) -> dict[str, object]:
         with self._lock:
-            qpos = self.data.qpos
-            x, y, z = (float(value) for value in qpos[self._base_qpos : self._base_qpos + 3])
-            qw, qx, qy, qz = (
-                float(value)
-                for value in qpos[self._base_qpos + 3 : self._base_qpos + 7]
-            )
-            yaw = math.atan2(
-                2.0 * (qw * qz + qx * qy),
-                1.0 - 2.0 * (qy * qy + qz * qz),
-            )
-            left = float(self.data.qvel[self._left_dof])
-            right = float(self.data.qvel[self._right_dof])
-            linear = WHEEL_RADIUS * (left + right) / 2.0
-            angular = WHEEL_RADIUS * (right - left) / WHEEL_TRACK
+            state = self.robot.state()
+            x, y, z, yaw = state.pose
+            linear, angular = state.velocity
             command = self._command
             frame = self._frame
             elapsed = max(time.monotonic() - self._started_at, 1e-6)
-            return {
+            snapshot = {
                 "pose": {"x": x, "y": y, "z": z, "yaw": yaw},
                 "velocity": {"linear": linear, "angular": angular},
                 "command": {"linear": command[0], "angular": command[1]},
@@ -134,43 +110,25 @@ class Simulation:
                     "fps": self._frame_count / elapsed,
                 },
             }
+            if state.telemetry:
+                snapshot["backend"] = state.telemetry
+            return snapshot
 
-    def _advance_kinematics(self, now: float) -> None:
-        linear, angular = self._command
-        if self._command_at and now - self._command_at > 0.35:
-            linear, angular = 0.0, 0.0
-            self._command = (0.0, 0.0)
-
-        previous_yaw = self._yaw
-        self._yaw = math.atan2(
-            math.sin(previous_yaw + angular * PHYSICS_DT),
-            math.cos(previous_yaw + angular * PHYSICS_DT),
-        )
-        heading = previous_yaw + angular * PHYSICS_DT / 2.0
-        self.data.qpos[self._base_qpos] += linear * math.cos(heading) * PHYSICS_DT
-        self.data.qpos[self._base_qpos + 1] += linear * math.sin(heading) * PHYSICS_DT
-        self.data.qpos[self._base_qpos + 3 : self._base_qpos + 7] = (
-            math.cos(self._yaw / 2.0),
-            0.0,
-            0.0,
-            math.sin(self._yaw / 2.0),
-        )
-
-        left = (linear - angular * WHEEL_TRACK / 2.0) / WHEEL_RADIUS
-        right = (linear + angular * WHEEL_TRACK / 2.0) / WHEEL_RADIUS
-        self.data.qpos[self._left_qpos] += left * PHYSICS_DT
-        self.data.qpos[self._right_qpos] += right * PHYSICS_DT
-        self.data.qvel.fill(0.0)
-        self.data.qvel[self._base_dof] = linear * math.cos(self._yaw)
-        self.data.qvel[self._base_dof + 1] = linear * math.sin(self._yaw)
-        self.data.qvel[self._base_dof + 5] = angular
-        self.data.qvel[self._left_dof] = left
-        self.data.qvel[self._right_dof] = right
-        self.data.time += PHYSICS_DT
-        mujoco.mj_forward(self.model, self.data)
+    def _advance(self, now: float) -> None:
+        command = self._command
+        if self._command_at and now - self._command_at > COMMAND_TIMEOUT_S:
+            command = (0.0, 0.0)
+            self._command = command
+        self.robot.step(command)
 
     def _run(self) -> None:
-        renderer = mujoco.Renderer(self.model, height=CAMERA_HEIGHT, width=CAMERA_WIDTH)
+        renderer = mujoco.Renderer(
+            self.model,
+            height=CAMERA_HEIGHT,
+            width=CAMERA_WIDTH,
+        )
+        third_person_camera = mujoco.MjvCamera()
+        mujoco.mjv_defaultCamera(third_person_camera)
         next_step = time.monotonic()
         next_frame = next_step
         try:
@@ -180,32 +138,37 @@ class Simulation:
                     time.sleep(min(next_step - now, 0.002))
                     continue
                 with self._lock:
-                    self._advance_kinematics(now)
+                    self._advance(now)
                 next_step += PHYSICS_DT
                 if now - next_step > 0.25:
                     next_step = now
                 if now >= next_frame:
                     with self._lock:
-                        renderer.update_scene(self.data, camera=CAMERA_NAME)
+                        renderer.update_scene(
+                            self.data,
+                            camera=self.robot.camera_name,
+                        )
                         rgb = np.asarray(renderer.render(), dtype=np.uint8).copy()
-                        renderer.update_scene(self.data, camera=THIRD_PERSON_CAMERA_NAME)
+                        render_camera = self.robot.third_person_camera(
+                            third_person_camera
+                        )
+                        renderer.update_scene(self.data, camera=render_camera)
                         third_person_rgb = np.asarray(
                             renderer.render(), dtype=np.uint8
                         ).copy()
-                        capture_pose = (
-                            float(self.data.qpos[self._base_qpos]),
-                            float(self.data.qpos[self._base_qpos + 1]),
-                            self._yaw,
-                        )
+                        x, y, _, yaw = self.robot.state().pose
+                        capture_pose = (x, y, yaw)
                     stamp_ns = time.time_ns()
                     frame = self._encode_frame(stamp_ns, rgb, capture_pose)
                     third_person_frame = self._encode_frame(
-                        stamp_ns, third_person_rgb, capture_pose
+                        stamp_ns,
+                        third_person_rgb,
+                        capture_pose,
                     )
                     with self._lock:
                         self._frame = frame
                         self._third_person_frame = third_person_frame
                         self._frame_count += 1
-                    next_frame = now + 0.05
+                    next_frame = now + FRAME_PERIOD_S
         finally:
             renderer.close()


### PR DESCRIPTION
## Summary

- define a small `RobotBackend` protocol for MuJoCo embodiments
- move the existing TurtleBot model, kinematics, state reporting, and camera selection into a backend
- keep threading, command watchdog, rendering, frame timestamps, and snapshots in the shared `Simulation` runtime
- namespace backend-specific telemetry under `simulation.backend`
- document the extension boundary and add backend/reset/watchdog regression tests

## Motivation

This keeps the bundled TurtleBot behavior as the default while allowing additional robot embodiments without duplicating the VLN client, MPC, web server, or render loop.

## Testing

- `uv run --extra dev pytest -q` — 16 passed
- Ruff on changed Python files
- EGL smoke test for first-person and third-person rendering
