### PR TITLE
mujoco_demo: add third-person picture-in-picture

### DIFF
--- a/mujoco_demo/tests/test_web_viewer.py
+++ b/mujoco_demo/tests/test_web_viewer.py
@@ -1,7 +1,6 @@
 from html.parser import HTMLParser
 from pathlib import Path
 
-
 WEB_DIR = Path(__file__).parents[1] / "vln_mujoco" / "web"
 
 

--- a/mujoco_demo/tests/test_web_viewer.py
+++ b/mujoco_demo/tests/test_web_viewer.py
@@ -1,0 +1,38 @@
+from html.parser import HTMLParser
+from pathlib import Path
+
+
+WEB_DIR = Path(__file__).parents[1] / "vln_mujoco" / "web"
+
+
+class ElementIdParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.ids: set[str] = set()
+
+    def handle_starttag(
+        self,
+        _tag: str,
+        attrs: list[tuple[str, str | None]],
+    ) -> None:
+        for name, value in attrs:
+            if name == "id" and value is not None:
+                self.ids.add(value)
+
+
+def test_third_person_picture_in_picture_controls_are_wired() -> None:
+    parser = ElementIdParser()
+    parser.feed((WEB_DIR / "index.html").read_text(encoding="utf-8"))
+    script = (WEB_DIR / "app.js").read_text(encoding="utf-8")
+    styles = (WEB_DIR / "styles.css").read_text(encoding="utf-8")
+
+    assert {
+        "third-person-overlay",
+        "third-person-overlay-image",
+        "third-person-overlay-toggle",
+    } <= parser.ids
+    assert '"/api/third-person.jpg"' in script
+    assert "Promise.allSettled(updates)" in script
+    assert 'storedBoolean("third-person-overlay-minimized")' in script
+    assert ".third-person-overlay.minimized" in styles
+    assert "@media (max-width: 560px)" in styles

--- a/mujoco_demo/vln_mujoco/web/app.js
+++ b/mujoco_demo/vln_mujoco/web/app.js
@@ -1,15 +1,26 @@
 (() => {
   "use strict";
   const $ = (id) => document.getElementById(id);
+  const storedBoolean = (key) => {
+    try { return localStorage.getItem(key) === "true"; } catch { return false; }
+  };
+  const storeBoolean = (key, value) => {
+    try { localStorage.setItem(key, String(value)); } catch { return; }
+  };
   const ui = {
-    cameraImage: $("camera-image"), path: $("path-overlay"),
+    cameraImage: $("camera-image"), path: $("path-overlay"), thirdPersonOverlay: $("third-person-overlay"),
+    thirdPersonOverlayImage: $("third-person-overlay-image"), thirdPersonOverlayToggle: $("third-person-overlay-toggle"),
     firstPersonView: $("first-person-view"), thirdPersonView: $("third-person-view"),
     simTime: $("sim-time"), cameraFps: $("camera-fps"), latency: $("latency"), count: $("waypoint-count"),
     serverUrl: $("server-url"), saveServer: $("save-server"), instruction: $("instruction"), vlnToggle: $("vln-toggle"),
     vlnState: $("vln-state"), vlnDetail: $("vln-detail"), controlToggle: $("control-toggle"), stop: $("stop-button"), reset: $("reset-button"),
     toast: $("toast")
   };
-  const state = {socket:null, connected:false, reconnect:null, data:null, keys:new Set(), toastTimer:null, cameraBusy:false, cameraUrl:null, cameraView:"first", serverUrlDirty:false};
+  const state = {
+    socket:null, connected:false, reconnect:null, data:null, keys:new Set(), toastTimer:null,
+    cameraBusy:false, cameraUrl:null, overlayCameraUrl:null, cameraView:"first",
+    overlayMinimized:storedBoolean("third-person-overlay-minimized"), serverUrlDirty:false
+  };
 
   function send(payload) {
     if (state.socket?.readyState !== WebSocket.OPEN) { toast("Web connection not ready", true); return false; }
@@ -46,28 +57,39 @@
       render();
     };
   }
+  async function refreshImage(image, endpoint, urlKey, isCurrent) {
+    let nextUrl = null;
+    try {
+      const response = await fetch(`${endpoint}?t=${Date.now()}`, {cache:"no-store"});
+      if (!response.ok) throw new Error("camera unavailable");
+      nextUrl = URL.createObjectURL(await response.blob());
+      if (!isCurrent()) return;
+      await new Promise((resolve, reject) => {
+        image.onload = resolve; image.onerror = reject; image.src = nextUrl;
+      });
+      if (!isCurrent()) return;
+      const oldUrl = state[urlKey]; state[urlKey] = nextUrl; nextUrl = null;
+      if (oldUrl) URL.revokeObjectURL(oldUrl);
+    } finally {
+      if (nextUrl) URL.revokeObjectURL(nextUrl);
+    }
+  }
   async function refreshCamera() {
     if (state.cameraBusy) return;
     state.cameraBusy = true;
     const cameraView = state.cameraView;
-    let nextUrl = null;
     try {
       const endpoint = cameraView === "third" ? "/api/third-person.jpg" : "/api/camera.jpg";
-      const response = await fetch(`${endpoint}?t=${Date.now()}`, {cache:"no-store"});
-      if (!response.ok) throw new Error("camera unavailable");
-      nextUrl = URL.createObjectURL(await response.blob());
-      if (cameraView !== state.cameraView) {
-        URL.revokeObjectURL(nextUrl);
-        nextUrl = null;
-        return;
+      const updates = [refreshImage(ui.cameraImage, endpoint, "cameraUrl", () => cameraView === state.cameraView)];
+      if (cameraView === "first") {
+        updates.push(refreshImage(
+          ui.thirdPersonOverlayImage,
+          "/api/third-person.jpg",
+          "overlayCameraUrl",
+          () => state.cameraView === "first"
+        ));
       }
-      await new Promise((resolve, reject) => {
-        ui.cameraImage.onload = resolve; ui.cameraImage.onerror = reject; ui.cameraImage.src = nextUrl;
-      });
-      const oldUrl = state.cameraUrl; state.cameraUrl = nextUrl; nextUrl = null;
-      if (oldUrl) URL.revokeObjectURL(oldUrl);
-    } catch (_) {
-      if (nextUrl) URL.revokeObjectURL(nextUrl);
+      await Promise.allSettled(updates);
     } finally { state.cameraBusy = false; }
   }
   function render() {
@@ -77,6 +99,12 @@
     ui.cameraFps.textContent = camera.ready ? `${Number(camera.fps || 0).toFixed(1)} Hz` : "—";
     ui.firstPersonView.classList.toggle("active", state.cameraView === "first");
     ui.thirdPersonView.classList.toggle("active", state.cameraView === "third");
+    ui.thirdPersonOverlay.hidden = state.cameraView !== "first";
+    ui.thirdPersonOverlay.classList.toggle("minimized", state.overlayMinimized);
+    ui.thirdPersonOverlayToggle.textContent = state.overlayMinimized ? "+" : "−";
+    ui.thirdPersonOverlayToggle.setAttribute("aria-label", state.overlayMinimized ? "Restore third-person view" : "Minimize third-person view");
+    ui.thirdPersonOverlayToggle.setAttribute("aria-expanded", String(!state.overlayMinimized));
+    ui.thirdPersonOverlayToggle.title = state.overlayMinimized ? "Restore third-person view" : "Minimize third-person view";
     ui.latency.textContent = Number.isFinite(Number(vln.latency_ms)) ? `${Number(vln.latency_ms).toFixed(0)} ms` : "—";
     const waypoints = Array.isArray(vln.waypoints) ? vln.waypoints : [];
     ui.count.textContent = String(waypoints.length);
@@ -155,6 +183,11 @@
   ui.saveServer.addEventListener("click", () => send({type:"set_server_url", server_url:ui.serverUrl.value.trim()}));
   ui.firstPersonView.addEventListener("click", () => { state.cameraView = "first"; render(); refreshCamera(); });
   ui.thirdPersonView.addEventListener("click", () => { state.cameraView = "third"; render(); refreshCamera(); });
+  ui.thirdPersonOverlayToggle.addEventListener("click", () => {
+    state.overlayMinimized = !state.overlayMinimized;
+    storeBoolean("third-person-overlay-minimized", state.overlayMinimized);
+    render();
+  });
   ui.vlnToggle.addEventListener("click", () => {
     const enabled = !state.data?.control?.auto;
     const instruction = ui.instruction.value.trim();

--- a/mujoco_demo/vln_mujoco/web/index.html
+++ b/mujoco_demo/vln_mujoco/web/index.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#0e1013">
   <title>VLN MuJoCo Console</title>
-  <link rel="stylesheet" href="/static/styles.css">
-  <script src="/static/app.js" defer></script>
+  <link rel="stylesheet" href="/static/styles.css?v=third-person-pip">
+  <script src="/static/app.js?v=third-person-pip" defer></script>
 </head>
 <body>
   <main class="shell">
@@ -21,8 +21,13 @@
         </div>
       </div>
       <div class="camera">
-        <img id="camera-image" alt="Live camera view of the TurtleBot in MuJoCo">
+        <img id="camera-image" alt="Live robot camera view in MuJoCo">
         <canvas id="path-overlay" width="480" height="270" aria-hidden="true"></canvas>
+        <div id="third-person-overlay" class="third-person-overlay">
+          <img id="third-person-overlay-image" alt="Third-person robot view in MuJoCo">
+          <span class="third-person-overlay-label">Third person</span>
+          <button id="third-person-overlay-toggle" class="third-person-overlay-toggle" type="button" aria-label="Minimize third-person view">−</button>
+        </div>
       </div>
       <div class="metrics">
         <span>SIM TIME<strong id="sim-time">0.0 s</strong></span>

--- a/mujoco_demo/vln_mujoco/web/styles.css
+++ b/mujoco_demo/vln_mujoco/web/styles.css
@@ -51,7 +51,25 @@ h1 { font-size: 20px; }
 
 .camera { position: relative; aspect-ratio: 16 / 9; background: #050608; }
 .camera img { width: 100%; height: 100%; display: block; object-fit: contain; }
-.camera canvas { position: absolute; inset: 0; width: 100%; height: 100%; pointer-events: none; }
+.camera canvas { position: absolute; z-index: 1; inset: 0; width: 100%; height: 100%; pointer-events: none; }
+.third-person-overlay {
+  position: absolute; z-index: 2; right: 14px; bottom: 14px; width: clamp(180px, 34%, 280px); aspect-ratio: 16 / 9;
+  overflow: hidden; background: #050608; border: 1px solid rgba(255,255,255,.72); border-radius: 6px;
+  box-shadow: 0 8px 28px rgba(0,0,0,.48); transition: width .18s ease, transform .18s ease;
+}
+.third-person-overlay[hidden] { display: none; }
+.third-person-overlay.minimized { width: clamp(112px, 18%, 150px); }
+.third-person-overlay img { width: 100%; height: 100%; object-fit: cover; }
+.third-person-overlay-label {
+  position: absolute; top: 7px; left: 8px; padding: 4px 6px; color: #fff; background: rgba(5,6,8,.72); border-radius: 3px;
+  font: 750 8px/1 ui-monospace, SFMono-Regular, monospace; letter-spacing: .08em; text-transform: uppercase;
+}
+.third-person-overlay-toggle {
+  position: absolute; top: 6px; right: 6px; width: 25px; height: 25px; padding: 0; color: #fff; background: rgba(5,6,8,.78);
+  border: 1px solid rgba(255,255,255,.34); border-radius: 3px; cursor: pointer; font: 800 16px/1 ui-monospace, SFMono-Regular, monospace;
+}
+.third-person-overlay-toggle:hover, .third-person-overlay-toggle:focus-visible { background: var(--accent); border-color: var(--accent-soft); outline: none; }
+.third-person-overlay.minimized .third-person-overlay-label { display: none; }
 .metrics { display: grid; grid-template-columns: repeat(4, 1fr); }
 .metrics span { padding: 12px 13px; color: var(--muted); border-right: 1px solid var(--line); font-size: 9px; }
 .metrics span:last-child { border-right: 0; }
@@ -99,6 +117,8 @@ input:focus, textarea:focus { border-color: var(--accent-deep); box-shadow: 0 0 
   .shell { padding: 10px; }
   .hero .section-head { align-items: flex-start; flex-direction: column; }
   .camera-actions { width: 100%; justify-content: space-between; }
+  .third-person-overlay { right: 8px; bottom: 8px; width: 42%; }
+  .third-person-overlay.minimized { width: 25%; }
   .metrics { grid-template-columns: repeat(2, 1fr); }
   .metrics span:nth-child(2) { border-right: 0; }
   .metrics span:nth-child(-n+2) { border-bottom: 1px solid var(--line); }


### PR DESCRIPTION
## Summary

- show the third-person camera as a picture-in-picture overlay while the main viewer is first-person
- hide the overlay when third-person is selected as the main view
- add minimize/restore controls and persist the preference in `localStorage`
- refresh the main and overlay images concurrently
- add responsive sizing for narrow mobile layouts
- add a static regression test for the viewer wiring

## Testing

- `node --check vln_mujoco/web/app.js`
- `uv run --extra dev pytest -q` — 13 passed
- headless Chrome visual checks at 1280×900 and 390×844
