### PR TITLE
mujoco_demo: add optional MicroDuck backend

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -100,6 +100,20 @@ wins.
 | `--record_fps`, `--record_timeline`, `--no_record_images` | `RECORD_FPS`, `RECORD_TIMELINE`, `RECORD_IMAGES` | `10`, `realtime`, images on | recording defaults written to the manifest / frame storage |
 | `--cam_hfov_deg`, `--cam_height`, `--traj_forward_offset`, `--waypoint_dt_s` | `CAM_HFOV_DEG`, `CAM_HEIGHT`, `TRAJ_FORWARD_OFFSET`, `WAYPOINT_DT_S` | `90`, `0.5`, auto, `0.1` | client-camera geometry and HUD convention used only by the rendered overlay |
 
+### MuJoCo demo parameters
+
+`mujoco_demo` is a separate `uv` project. Run `./run.sh` for its bundled
+TurtleBot, or use `uv run --extra microduck vln-mujoco ...` when selecting the
+optional MicroDuck backend.
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `--host` / `--port` | `127.0.0.1` / `8088` | web-console bind address |
+| `--vln-server` | empty | default LightNav WebSocket URL shown in the console |
+| `--robot` | `turtlebot` | robot backend: `turtlebot` or `microduck` |
+| `--robot-model` | none | external MicroDuck MJCF; required only with `--robot microduck` |
+| `--walking-policy` | none | external MicroDuck ONNX policy; required only with `--robot microduck` |
+
 Engine-level environment variables (no flag):
 
 | Variable | Default | Meaning |
@@ -160,4 +174,3 @@ Frames within one session must share one size (the first frame decides; `reset` 
 over). `keep` avoids geometric distortion but changes the token grid the model sees, which
 the released checkpoint was not trained on — validate on your robot before relying on it.
 Full native resolution (feeding the camera's own pixel count) is not supported.
-

--- a/mujoco_demo/README.md
+++ b/mujoco_demo/README.md
@@ -1,22 +1,23 @@
 # mujoco_demo
 
-A small, self-contained TurtleBot vision-language-navigation simulation
-(Python package `vln_mujoco`): it runs
+A small vision-language-navigation simulation (Python package `vln_mujoco`):
+it runs
 in the fixed MolmoSpaces ProcTHOR 10K validation `val_2` multi-room scene, using
-the ceiling MJCF variant, TurtleBot kinematics, and MuJoCo RGB camera rendering,
-with a single web page for VLN instructions, live view, WASD driving, emergency
-stop, reset, and state readout.
+the ceiling MJCF variant, MuJoCo RGB camera rendering, and either the bundled
+TurtleBot or an external MicroDuck model and walking policy. A single web page
+provides VLN instructions, live view, WASD driving, emergency stop, reset, and
+state readout.
 
 ## Highlights
 
 - One scene: only the MolmoSpaces resources actually referenced by
   `val_2_ceiling` are bundled — no full dataset download required;
-- One robot: a differential-drive TurtleBot geometry defined in-project, with no
-  external meshes;
+- Two robot modes: a differential-drive TurtleBot defined in-project, or an
+  optional dynamically simulated MicroDuck driven by an ONNX walking policy;
 - One process: Python runs MuJoCo, the web page, and the VLN WebSocket client
   together;
-- Pure kinematics: velocity commands are integrated directly into the TurtleBot
-  pose — no motors, gravity, or contact dynamics;
+- TurtleBot commands are integrated kinematically; MicroDuck runs gravity,
+  contacts, 14 position actuators, and policy inference at 50 Hz;
 - Two views: the web page switches live between the robot's first-person RGB
   and a rear-elevated third-person follow camera;
 - On-change state sync: web state is pushed only when the robot, VLN, control
@@ -25,7 +26,7 @@ stop, reset, and state readout.
   `stop=true` ends the task and releases control automatically;
 - MPC control: the same CasADi/IPOPT unicycle MPC, parameters, and
   capture-time pose alignment as `robot_deploy`'s `vln_mpc`;
-- No ROS 2, no Node.js, no locomotion policy;
+- No ROS 2 or Node.js; the default TurtleBot mode needs no locomotion policy;
 - The web interaction and VLN server protocol are compatible with
   `robot_deploy`'s `vln_web` and `vln_client`.
 
@@ -46,6 +47,34 @@ address can also be set at startup:
 ./run.sh --host 0.0.0.0 --port 8088
 ```
 
+### MicroDuck (optional)
+
+MicroDuck support deliberately keeps the robot MJCF, meshes, and walking policy
+outside this repository. Obtain those files from their owners under terms that
+permit your use, then start the demo with the optional ONNX Runtime dependency:
+
+```bash
+MUJOCO_GL=egl uv run --extra microduck vln-mujoco \
+  --host 0.0.0.0 \
+  --vln-server ws://127.0.0.1:8050 \
+  --robot microduck \
+  --robot-model /path/to/microduck_rl/src/mjlab_microduck/robot/microduck/robot_allcollisions.xml \
+  --walking-policy /path/to/alpha_walking.onnx
+```
+
+The MJCF must provide `trunk_base`, `trunk_base_freejoint`, `head_camera`, the
+`imu_ang_vel` three-axis sensor, and 14 joint actuators. The ONNX policy must
+accept one `[1, 61]` float32 observation, return one `[1, 14]` float32 action,
+and provide `joint_names`, `default_joint_pos`, `action_scale`,
+`observation_names`, and `command_names` metadata. Actuator order must match
+`joint_names`; incompatible files fail at startup instead of running with an
+incorrect joint mapping.
+
+The head camera is used for LightNav input, while MuJoCo trunk pose and velocity
+provide MPC feedback. Commands are clipped to the policy range (`±0.30 m/s`,
+`±1.50 rad/s`); small non-zero linear commands enter the stable walking range,
+while commands inside the stop deadband remain zero.
+
 Pressing space or clicking `STOP` on the page zeroes the velocity immediately.
 Manual commands also auto-zero when not refreshed for 350 ms.
 
@@ -60,9 +89,9 @@ PORT=8050 CUDA_VISIBLE_DEVICES=0 lightnav-serve \
 ```
 
 Then paste `ws://<gpu-host>:8050` into the console's **VLN Server WebSocket**
-field, type an instruction, and press **Start VLN**. The simulated TurtleBot
-streams its first-person frames to the server and tracks the returned waypoints
-with the MPC — the same client protocol and controller the real robots use in
+field, type an instruction, and press **Start VLN**. The selected simulated
+robot streams its first-person frames to the server and tracks the returned
+waypoints with the MPC — the same client protocol and controller the real robots use in
 [`robot_deploy/`](../robot_deploy/README.md).
 
 ## Layout
@@ -72,7 +101,7 @@ mujoco_demo/
 ├── vln_mujoco/
 │   ├── assets/        # a single MolmoSpaces scene, nothing more
 │   ├── web/           # static single page, no build step
-│   ├── robots/        # robot backend protocol + TurtleBot implementation
+│   ├── robots/        # backend protocol + TurtleBot and MicroDuck adapters
 │   ├── model.py       # scene loading and MuJoCo compilation
 │   ├── simulation.py  # shared runtime, cameras, watchdog, frame capture
 │   ├── mpc.py         # CasADi/IPOPT kinematic MPC
@@ -153,6 +182,7 @@ endorsed by Open Robotics or ROBOTIS.
 
 - The TurtleBot is a lightweight geometry drawn for this project, not the
   official high-fidelity TurtleBot3 mesh;
+- MicroDuck mode requires external MJCF assets and a compatible ONNX policy;
 - The spawn pose is fixed at `(x=6.5, y=13.8, yaw=0)` and environment objects
   are frozen;
 - RGB only for now, at a camera resolution of `480 × 270`;

--- a/mujoco_demo/README.md
+++ b/mujoco_demo/README.md
@@ -72,8 +72,9 @@ mujoco_demo/
 ├── vln_mujoco/
 │   ├── assets/        # a single MolmoSpaces scene, nothing more
 │   ├── web/           # static single page, no build step
-│   ├── model.py       # scene + TurtleBot MJCF
-│   ├── simulation.py  # kinematics, cameras, wheel visualisation
+│   ├── robots/        # robot backend protocol + TurtleBot implementation
+│   ├── model.py       # scene loading and MuJoCo compilation
+│   ├── simulation.py  # shared runtime, cameras, watchdog, frame capture
 │   ├── mpc.py         # CasADi/IPOPT kinematic MPC
 │   ├── vln_client.py  # VLN WebSocket client
 │   └── server.py      # HTTP/WebSocket and control ownership
@@ -81,6 +82,15 @@ mujoco_demo/
 ├── tests/
 └── run.sh
 ```
+
+The simulation runtime is independent of the bundled TurtleBot embodiment.
+Robot implementations satisfy the `RobotBackend` protocol in
+`vln_mujoco/robots/base.py`: they provide a MuJoCo model and data, consume the
+shared planar velocity command, report pose and velocity, and select the two
+render cameras. The runtime continues to own threading, command timeout,
+rendering, frame timestamps, and the server-facing snapshot. A new embodiment
+therefore does not need to modify the VLN client, MPC, web server, or render
+loop.
 
 Body-frame waypoints returned by VLN are first transformed into the world frame
 using the robot pose at image-capture time, then tracked by the MPC in the

--- a/mujoco_demo/pyproject.toml
+++ b/mujoco_demo/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "vln-mujoco"
 version = "0.1.0"
-description = "A small self-contained TurtleBot VLN simulator in one MolmoSpaces scene."
+description = "A small robot-backend VLN simulator in one MolmoSpaces scene."
 readme = "README.md"
 authors = [{ name = "Light Origins" }]
 license = "Apache-2.0"
@@ -16,6 +16,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["pytest>=8.0", "pytest-asyncio>=0.23"]
+microduck = ["onnxruntime>=1.24"]
 
 [project.scripts]
 vln-mujoco = "vln_mujoco.__main__:main"

--- a/mujoco_demo/tests/test_cli.py
+++ b/mujoco_demo/tests/test_cli.py
@@ -1,0 +1,21 @@
+import pytest
+from vln_mujoco.__main__ import parse_args, simulation_from_args
+
+
+def test_turtlebot_is_the_default_robot() -> None:
+    args = parse_args([])
+    assert args.robot == "turtlebot"
+    assert args.robot_model is None
+    assert args.walking_policy is None
+
+
+def test_microduck_requires_model_and_policy_paths() -> None:
+    args = parse_args(["--robot", "microduck"])
+    with pytest.raises(SystemExit, match="requires --robot-model"):
+        simulation_from_args(args)
+
+
+def test_turtlebot_rejects_microduck_only_paths() -> None:
+    args = parse_args(["--robot-model", "robot.xml"])
+    with pytest.raises(SystemExit, match="require --robot microduck"):
+        simulation_from_args(args)

--- a/mujoco_demo/tests/test_microduck.py
+++ b/mujoco_demo/tests/test_microduck.py
@@ -1,0 +1,244 @@
+from pathlib import Path
+
+import mujoco
+import numpy as np
+import pytest
+from vln_mujoco.robots.microduck import (
+    BASE_JOINT_NAME,
+    CAMERA_NAME,
+    EXPECTED_COMMAND_NAMES,
+    EXPECTED_OBSERVATION_NAMES,
+    IMU_SENSOR_NAME,
+    MODEL_PREFIX,
+    TRUNK_BODY_NAME,
+    MicroDuckBackend,
+    MicroDuckPolicy,
+    build_model,
+    shape_microduck_command,
+)
+
+JOINT_NAMES = (
+    "left_hip_yaw",
+    "left_hip_roll",
+    "left_hip_pitch",
+    "left_knee",
+    "left_ankle",
+    "neck_pitch",
+    "head_pitch",
+    "head_yaw",
+    "head_roll",
+    "right_hip_yaw",
+    "right_hip_roll",
+    "right_hip_pitch",
+    "right_knee",
+    "right_ankle",
+)
+DEFAULT_POSE = np.asarray(
+    [
+        0.0,
+        -0.087,
+        -0.458,
+        -0.005,
+        0.453,
+        0.349,
+        0.349,
+        0.0,
+        0.0,
+        0.0,
+        0.087,
+        0.458,
+        0.005,
+        -0.453,
+    ],
+    dtype=np.float32,
+)
+
+
+class FakeTensorInfo:
+    def __init__(self, name: str, shape: list[int], tensor_type: str) -> None:
+        self.name = name
+        self.shape = shape
+        self.type = tensor_type
+
+
+class FakeMetadata:
+    def __init__(self, values: dict[str, str]) -> None:
+        self.custom_metadata_map = values
+
+
+class FakeSession:
+    def __init__(
+        self,
+        *,
+        joint_names: tuple[str, ...] = JOINT_NAMES,
+        action: np.ndarray | None = None,
+    ) -> None:
+        self._inputs = [FakeTensorInfo("obs", [1, 61], "tensor(float)")]
+        self._outputs = [FakeTensorInfo("actions", [1, 14], "tensor(float)")]
+        self._metadata = FakeMetadata(
+            {
+                "joint_names": ",".join(joint_names),
+                "default_joint_pos": ",".join(str(value) for value in DEFAULT_POSE),
+                "action_scale": "0.5",
+                "observation_names": ",".join(EXPECTED_OBSERVATION_NAMES),
+                "command_names": ",".join(EXPECTED_COMMAND_NAMES),
+            }
+        )
+        self.action = (
+            action
+            if action is not None
+            else np.arange(14, dtype=np.float32).reshape(1, 14) / 100.0
+        )
+        self.last_observation: np.ndarray | None = None
+
+    def get_inputs(self) -> list[FakeTensorInfo]:
+        return self._inputs
+
+    def get_outputs(self) -> list[FakeTensorInfo]:
+        return self._outputs
+
+    def get_modelmeta(self) -> FakeMetadata:
+        return self._metadata
+
+    def run(
+        self,
+        _output_names: list[str],
+        input_feed: dict[str, np.ndarray],
+    ) -> list[np.ndarray]:
+        self.last_observation = input_feed["obs"].copy()
+        return [self.action.copy()]
+
+
+def write_test_models(tmp_path: Path) -> tuple[Path, Path]:
+    scene = tmp_path / "scene.xml"
+    scene.write_text(
+        """
+        <mujoco model="test_scene">
+          <worldbody>
+            <geom name="floor" type="plane" size="20 20 0.1" />
+          </worldbody>
+        </mujoco>
+        """,
+        encoding="utf-8",
+    )
+    bodies = "\n".join(
+        f"""
+        <body name="{name}_body" pos="0 0 0.01">
+          <joint name="{name}" type="hinge" axis="0 1 0" />
+          <geom type="capsule" size="0.005 0.01" mass="0.01" />
+        </body>
+        """
+        for name in JOINT_NAMES
+    )
+    actuators = "\n".join(
+        f'<position name="{name}" joint="{name}" kp="1" />'
+        for name in JOINT_NAMES
+    )
+    robot = tmp_path / "robot.xml"
+    robot.write_text(
+        f"""
+        <mujoco model="microduck_test">
+          <worldbody>
+            <body name="trunk_base" pos="0 0 0.12">
+              <freejoint name="trunk_base_freejoint" />
+              <geom type="box" size="0.03 0.02 0.02" mass="1" />
+              <site name="imu" size="0.005" />
+              <camera name="head_camera" pos="0.03 0 0" />
+              {bodies}
+            </body>
+          </worldbody>
+          <sensor><gyro name="imu_ang_vel" site="imu" /></sensor>
+          <actuator>{actuators}</actuator>
+        </mujoco>
+        """,
+        encoding="utf-8",
+    )
+    return scene, robot
+
+
+def test_microduck_command_stops_inside_deadband() -> None:
+    assert shape_microduck_command(0.05, 0.01) == (0.0, 0.0)
+    assert shape_microduck_command(float("nan"), 0.4) == (0.0, 0.0)
+
+
+def test_microduck_command_enters_stable_gait_range() -> None:
+    linear, angular = shape_microduck_command(0.15, 0.4)
+    assert linear == pytest.approx(0.28)
+    assert angular == pytest.approx(0.4)
+
+
+def test_microduck_command_is_clamped_to_policy_range() -> None:
+    assert shape_microduck_command(2.0, -4.0) == pytest.approx((0.3, -1.5))
+
+
+def test_microduck_model_is_namespaced(tmp_path: Path) -> None:
+    scene, robot = write_test_models(tmp_path)
+    model = build_model(robot, scene)
+
+    assert model.nu == 14
+    assert model.body(TRUNK_BODY_NAME).id >= 0
+    assert model.joint(BASE_JOINT_NAME).id >= 0
+    assert model.camera(CAMERA_NAME).id >= 0
+    assert model.sensor(IMU_SENSOR_NAME).id >= 0
+    assert all(
+        model.actuator(index).name == f"{MODEL_PREFIX}{name}"
+        for index, name in enumerate(JOINT_NAMES)
+    )
+
+
+def test_policy_uses_metadata_for_observation_and_action(tmp_path: Path) -> None:
+    scene, robot = write_test_models(tmp_path)
+    model = build_model(robot, scene)
+    data = mujoco.MjData(model)
+    session = FakeSession()
+    policy = MicroDuckPolicy(model, data, tmp_path / "unused.onnx", session)
+    data.qpos[policy.joint_qpos] = policy.default_pose
+    mujoco.mj_forward(model, data)
+
+    assert policy.set_velocity(0.15, 0.4) == pytest.approx((0.28, 0.4))
+    observation = policy.observation()
+    assert observation.shape == (61,)
+    assert observation[-13] == pytest.approx(0.28)
+    assert observation[-11] == pytest.approx(0.4)
+
+    policy.step()
+
+    assert session.last_observation is not None
+    assert session.last_observation.shape == (1, 61)
+    assert data.ctrl == pytest.approx(DEFAULT_POSE + session.action[0] * 0.5)
+
+
+def test_policy_rejects_mismatched_joint_order(tmp_path: Path) -> None:
+    scene, robot = write_test_models(tmp_path)
+    model = build_model(robot, scene)
+    data = mujoco.MjData(model)
+    wrong_order = tuple(reversed(JOINT_NAMES))
+
+    with pytest.raises(ValueError, match="joint_names"):
+        MicroDuckPolicy(
+            model,
+            data,
+            tmp_path / "unused.onnx",
+            FakeSession(joint_names=wrong_order),
+        )
+
+
+def test_microduck_backend_implements_shared_runtime_contract(tmp_path: Path) -> None:
+    scene, robot = write_test_models(tmp_path)
+    backend = MicroDuckBackend(
+        robot,
+        tmp_path / "unused.onnx",
+        policy_session=FakeSession(),
+        scene_source=scene,
+    )
+
+    backend.step((0.15, 0.4))
+    state = backend.state()
+    camera = mujoco.MjvCamera()
+    mujoco.mjv_defaultCamera(camera)
+
+    assert state.telemetry["policy_command"] == pytest.approx(
+        {"linear": 0.28, "angular": 0.4}
+    )
+    assert backend.third_person_camera(camera) is camera
+    assert camera.type == mujoco.mjtCamera.mjCAMERA_FREE

--- a/mujoco_demo/tests/test_model.py
+++ b/mujoco_demo/tests/test_model.py
@@ -1,12 +1,10 @@
 import mujoco
-
-from vln_mujoco.model import CAMERA_NAME, build_model
+from vln_mujoco.robots.turtlebot import CAMERA_NAME, TurtleBotBackend
 
 
 def test_bundled_scene_and_robot_compile() -> None:
-    model = build_model()
+    model = TurtleBotBackend().model
     assert model.nu == 0  # pure kinematics: no actuators by design
     assert model.camera(CAMERA_NAME).id >= 0
     assert model.body("base_link").id >= 0
     assert mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_GEOM, "floor") >= 0
-

--- a/mujoco_demo/tests/test_robot_backend.py
+++ b/mujoco_demo/tests/test_robot_backend.py
@@ -1,0 +1,71 @@
+import time
+
+import pytest
+from vln_mujoco.robots.base import RobotState
+from vln_mujoco.robots.turtlebot import TurtleBotBackend
+from vln_mujoco.simulation import COMMAND_TIMEOUT_S, Simulation
+
+
+class TelemetryTurtleBot(TurtleBotBackend):
+    def state(self) -> RobotState:
+        state = super().state()
+        return RobotState(
+            pose=state.pose,
+            velocity=state.velocity,
+            telemetry={"pose": "backend-pose", "policy_command": {"linear": 0.3}},
+        )
+
+
+def test_turtlebot_backend_integrates_velocity_command() -> None:
+    robot = TurtleBotBackend()
+    start = robot.state()
+
+    for _ in range(20):
+        robot.step((0.4, 0.2))
+
+    state = robot.state()
+    assert state.pose[0] > start.pose[0]
+    assert state.pose[1] > start.pose[1]
+    assert state.pose[3] > start.pose[3]
+    assert state.velocity == pytest.approx((0.4, 0.2))
+
+
+def test_turtlebot_backend_reset_restores_spawn_pose() -> None:
+    robot = TurtleBotBackend()
+    robot.step((0.4, 0.2))
+
+    robot.reset()
+
+    state = robot.state()
+    assert state.pose == pytest.approx((6.5, 13.8, 0.033, 0.0))
+    assert state.velocity == pytest.approx((0.0, 0.0))
+
+
+def test_simulation_owns_command_watchdog_and_robot_identity() -> None:
+    simulation = Simulation(TurtleBotBackend())
+    simulation.set_velocity(0.4, 0.2)
+    simulation._advance(time.monotonic())
+
+    assert simulation.robot_name == "TurtleBot"
+    assert simulation.snapshot()["command"] == pytest.approx(
+        {"linear": 0.4, "angular": 0.2}
+    )
+
+    simulation._command_at = time.monotonic() - COMMAND_TIMEOUT_S - 0.1
+    simulation._advance(time.monotonic())
+
+    assert simulation.snapshot()["command"] == pytest.approx(
+        {"linear": 0.0, "angular": 0.0}
+    )
+
+
+def test_simulation_namespaces_backend_telemetry() -> None:
+    simulation = Simulation(TelemetryTurtleBot())
+
+    snapshot = simulation.snapshot()
+
+    assert isinstance(snapshot["pose"], dict)
+    assert snapshot["backend"] == {
+        "pose": "backend-pose",
+        "policy_command": {"linear": 0.3},
+    }

--- a/mujoco_demo/uv.lock
+++ b/mujoco_demo/uv.lock
@@ -225,6 +225,14 @@ epath = [
 ]
 
 [[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
+]
+
+[[package]]
 name = "frozenlist"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -684,6 +692,44 @@ wheels = [
 ]
 
 [[package]]
+name = "onnxruntime"
+version = "1.29.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flatbuffers" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "packaging" },
+    { name = "protobuf" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/a8/0520890321b8ff40b908cf165a93eb58fbc8f85c14db637277ea866c9544/onnxruntime-1.29.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:07c5907474dec4a2792fd7626b753dc66707808385a6d9eecf993db0066a9d0f", size = 21420890, upload-time = "2026-08-17T22:53:33.429Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/77/8bd3e0008ff8d386305351109a7329ea57e51a3ab57bc92340f29c4a5b5d/onnxruntime-1.29.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:16925ef8497e2c07e4b5ae15b504079b3ab3f65e22c58efd10dde0f3caea969a", size = 20803602, upload-time = "2026-08-17T22:53:36.47Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/91/a66cd77f28379ede419672edda3184f1eb286db215dce1e7b976fae2d63b/onnxruntime-1.29.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:85f8e8406c52658735fe5c7fbfd3ebaa1ed340768324f6252e4274e374580a23", size = 23113193, upload-time = "2026-08-17T22:53:39.732Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/82/2da968405c42340f03de0bcdb63be09ae1004f820b2295590d48951b5cf2/onnxruntime-1.29.0-cp311-cp311-win_amd64.whl", hash = "sha256:0d4f427afac434b0070fe992b540ddf20a7aff2265f760f314d91331935b6b98", size = 13999253, upload-time = "2026-08-17T22:53:43.184Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7a/70c9c893bf732ee66124c2d8de6a21fc9361ec62cf378f857043efcbf0eb/onnxruntime-1.29.0-cp311-cp311-win_arm64.whl", hash = "sha256:4eae472cf7dc3107dec1bb53cd6d142d1964616d08aae48654cd4254b2363c4b", size = 13741410, upload-time = "2026-08-17T22:53:45.521Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/80/381c1e9efed9cc32d00aa7cab0547dc84116cec906c3ffe3613686d6963a/onnxruntime-1.29.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3a3814c041251d6a77fdf513fb282056538ee826d2f1178a0df3c549d3fff6ba", size = 21430049, upload-time = "2026-08-17T22:53:48.286Z" },
+    { url = "https://files.pythonhosted.org/packages/30/12/4be0e345d38fe707a701ca07e8f63c05b152a2e6285d1e43a7faf63fedd2/onnxruntime-1.29.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:d2fb19e848f7c33ed8d3182b52504aaa11c5e8da438bbb47296f85b133cbcf6b", size = 20816870, upload-time = "2026-08-17T22:53:51.169Z" },
+    { url = "https://files.pythonhosted.org/packages/96/eb/e6968f5e41aac3125f2ff5708855f09cb0b70d85ed3115b625b0b58305ba/onnxruntime-1.29.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:2b80d8c7ec2cc7438e4da3760b88c24568cba72c9ace96d668800a6c79419acb", size = 23136745, upload-time = "2026-08-17T22:53:53.92Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/80/5b28f1f1111210fc4a336ddbc6950f468ebf9a6a265420568f4f43fa33ce/onnxruntime-1.29.0-cp312-cp312-win_amd64.whl", hash = "sha256:4acf2b4948b7ede87221ca6332344b8facdc8059d6ac751a7d367d04532b02dd", size = 14001407, upload-time = "2026-08-17T22:53:56.486Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d6/6883f89ea4b044e6e8447ebfaf9bcecdf457b7d80a683635e130b25498e0/onnxruntime-1.29.0-cp312-cp312-win_arm64.whl", hash = "sha256:dc61a79cb39afd66ab3f01fd2c23591a7f01de89c1668e1fb6315067fc279164", size = 13746981, upload-time = "2026-08-17T22:53:58.977Z" },
+    { url = "https://files.pythonhosted.org/packages/41/f8/d375facf60edaf41f5732f9f689c98a800fcc52df5cf6ddfb406703eb5a1/onnxruntime-1.29.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:be0f8ed688cfb1d4d5765a137193b7bfab0c8ea214eed99260b380bb525a3a7f", size = 21429708, upload-time = "2026-08-17T22:54:01.44Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/17/b9ad04051a8c4f504852ce0e8e10f9a6b2f1a331eedcdcc503df776dd0ea/onnxruntime-1.29.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:d67673c5367727860922c5262d724472f1b5539fb7ccf4c81a638f9b71719803", size = 20816263, upload-time = "2026-08-17T22:54:04.088Z" },
+    { url = "https://files.pythonhosted.org/packages/83/2c/d8eb945d2a372149df9705a8d5c8d7c6c46c987c5446dbcea9e1ea7f6556/onnxruntime-1.29.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:e2128f31f449e922c62dbe5d8b6b7b079f0bcaf2d56a102fa203cb6e5bb5ab19", size = 23136817, upload-time = "2026-08-17T22:54:06.714Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/3b/66b424c63fa92dfaa48d1719efaae66fc8c256b9426a832eda51d8dfe1e9/onnxruntime-1.29.0-cp313-cp313-win_amd64.whl", hash = "sha256:2945e1f82f81f27e88decea88c7861f45baea23818950d467bf3909aa303119e", size = 14001310, upload-time = "2026-08-17T22:54:09.13Z" },
+    { url = "https://files.pythonhosted.org/packages/83/22/d6a700e3a6322fa3d56fbe7cee9ffc53f35e77ffcd6b7e97f4b7722a27ab/onnxruntime-1.29.0-cp313-cp313-win_arm64.whl", hash = "sha256:4b940b0d777590c7e20bf298f5c16af1ea6ad1b400a1c822a6be192f64f4d954", size = 13747112, upload-time = "2026-08-17T22:54:11.608Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/89/c4af146de3d60a32c89fea48d5d34bfd044faaf8957270043a03bd1b462b/onnxruntime-1.29.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:533f8370ce124304e5cb08ab961836cf755631e3dd77adc5f3bbdab70c2b7d99", size = 20826136, upload-time = "2026-08-17T22:54:14.315Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f2/e6bbacd11dfe8d070613261a758795ea128b9fc9bea391a2a7da2e4c7a08/onnxruntime-1.29.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:c1ad3f437153fe77f9d01a08fbaac0beb030e09b8a80ace1603bcf69b6c95481", size = 23138951, upload-time = "2026-08-17T22:54:17.154Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/a3/718e1b83096a1bc7b0fc8014c23d4cf795559fe666961cfac4fc038a4871/onnxruntime-1.29.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:e74b278af1d949876f5d91d1268fd6c680e79f2bac194967394eaba9fdf69e7e", size = 21431104, upload-time = "2026-08-17T22:54:20.118Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/17/c75e78ddc1fe69b6ebaef7fe88ac83f29bfe10955e3a0d2436d93473c91c/onnxruntime-1.29.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:939e5d65f332e6d399774b2bd0d3559fd8fa629c1e77833db29d968d2384f23d", size = 20818488, upload-time = "2026-08-17T22:54:23.147Z" },
+    { url = "https://files.pythonhosted.org/packages/65/54/9f197c578d3d3d7bea16971e233e5483981228eec73748585cf7b5933403/onnxruntime-1.29.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:6c0c37b92f67ed68dd36221ce0403e1d9bd4f7efce724439978a2597848530e5", size = 23136994, upload-time = "2026-08-17T22:54:26.321Z" },
+    { url = "https://files.pythonhosted.org/packages/24/53/4616a55d2495679cfd0195f968feb3d74fe30e26467d168ee243ac97c089/onnxruntime-1.29.0-cp314-cp314-win_amd64.whl", hash = "sha256:4a3129ae56e70d2618ff773920166916310370a7e3cacb60b9e0e8910092725f", size = 14350643, upload-time = "2026-08-17T22:54:28.794Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/0f/c338cb5500a522c7e671a3bb1276f4562404fbecce8a0e274565aa968484/onnxruntime-1.29.0-cp314-cp314-win_arm64.whl", hash = "sha256:e417ef8628dcce310d2d53023e750ea298ec14d4341ae6dc3a572bfd9bc7fa97", size = 14124294, upload-time = "2026-08-17T22:54:31.015Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/e7/61064289a9a1301b25c1f0f574fe98aba31c2d388db3c1dbec664f78621f/onnxruntime-1.29.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:11264bb58f7b7cf6af835ab10d36838d73680580820fd6f51d90124a1ca8f449", size = 20826174, upload-time = "2026-08-17T22:54:34.283Z" },
+    { url = "https://files.pythonhosted.org/packages/60/21/d0c04b561b46e9bff89b5f500fb7415b8ca0669f7902204f76ab06bb0c7e/onnxruntime-1.29.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:1ea91cef3b971506e51ae9c37c16d027774ec64994a524ec1bdfb027d68a9832", size = 23138547, upload-time = "2026-08-17T22:54:37.491Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.3"
 source = { registry = "https://pypi.org/simple" }
@@ -898,6 +944,21 @@ wheels = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "7.36.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/73/f66c748df06e7fe24e658eddd600d19c4b40bad836c97ce2d0ad9851fb6b/protobuf-7.36.1.tar.gz", hash = "sha256:d0f6470f0ce2b84e3feaea2d4b816378b37ba4d4aa08a274305373de93e2d524", size = 512499, upload-time = "2026-08-31T22:40:04.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/6c/3a54a58f2948b0f485df9ecdd06590f15d0a7abf46a89d50c3de709ff4ff/protobuf-7.36.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:3cf2ee25d006cee57294a1196ea43b37feb78e0dcd1e8af5c1aeddb777655aca", size = 456046, upload-time = "2026-08-31T22:39:56.865Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/08/9f9548793c771095245c0eeaf0c84b76b16a5ef26158043d456f551344a0/protobuf-7.36.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:43d3d37b1eb24c113b9b7d02008cac44e423f00b611b7781ae998d7623972969", size = 344226, upload-time = "2026-08-31T22:39:58.263Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/51/1bdbd612fa3c51e42ea6f45d05e84dc748ddcd2663e1aa1e89a00a33facd/protobuf-7.36.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:39c518c05586c016d7874ff6079ee115bcec1ea5fbb1d177fbf7867ef4c67e44", size = 357229, upload-time = "2026-08-31T22:39:59.198Z" },
+    { url = "https://files.pythonhosted.org/packages/22/df/c799fe7a05ef16ba853a59db01f3a2c5f7d0676469589ccc4874f76a2a88/protobuf-7.36.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:97198b77e369a0abd8e262b8f6c7266c55ddb796a3a12c76d7b8881188ed83aa", size = 343228, upload-time = "2026-08-31T22:40:00.179Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/33/d4724ec5d86d496fe4108e220618aa0837ad3423a7af7ccdd9684ccc77c8/protobuf-7.36.1-cp310-abi3-win32.whl", hash = "sha256:0b53ce95272aad50ad25d7ff03373743209822e8ba42ea7fad27d2bee1547d00", size = 443002, upload-time = "2026-08-31T22:40:01.32Z" },
+    { url = "https://files.pythonhosted.org/packages/db/37/155788a0d8daded960375af604202805308169f9b859419ea0aa370946e2/protobuf-7.36.1-cp310-abi3-win_amd64.whl", hash = "sha256:51139351435d9b43d88a55eaa49fb6f737fbb478fb0cbf2cf694d1a04a9d3363", size = 456518, upload-time = "2026-08-31T22:40:02.494Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ca/c47f91d3cab175b01fd8c4f0d80fdf8613be876cc616e66ad281a59c5ddf/protobuf-7.36.1-py3-none-any.whl", hash = "sha256:7d951e46b3f963d6c264c367c437921de9d5aedd9c3f9612b9077736b4e3ad5c", size = 179813, upload-time = "2026-08-31T22:40:03.54Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
@@ -971,6 +1032,9 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
 ]
+microduck = [
+    { name = "onnxruntime" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -978,11 +1042,12 @@ requires-dist = [
     { name = "casadi", specifier = ">=3.7,<4" },
     { name = "mujoco", specifier = ">=3.3" },
     { name = "numpy", specifier = ">=1.24" },
+    { name = "onnxruntime", marker = "extra == 'microduck'", specifier = ">=1.24" },
     { name = "pillow", specifier = ">=10.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "microduck"]
 
 [[package]]
 name = "yarl"

--- a/mujoco_demo/vln_mujoco/__main__.py
+++ b/mujoco_demo/vln_mujoco/__main__.py
@@ -1,25 +1,54 @@
 from __future__ import annotations
 
 import argparse
+from pathlib import Path
+from typing import Sequence
 
 from aiohttp import web
 
 from .server import VlnMujocoServer
+from .simulation import Simulation
 
 
-def parse_args() -> argparse.Namespace:
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run the vln_mujoco simulator")
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8088)
     parser.add_argument("--vln-server", default="")
-    return parser.parse_args()
+    parser.add_argument(
+        "--robot",
+        choices=("turtlebot", "microduck"),
+        default="turtlebot",
+    )
+    parser.add_argument("--robot-model", type=Path)
+    parser.add_argument("--walking-policy", type=Path)
+    return parser.parse_args(argv)
+
+
+def simulation_from_args(args: argparse.Namespace) -> Simulation:
+    if args.robot == "turtlebot":
+        if args.robot_model is not None or args.walking_policy is not None:
+            raise SystemExit(
+                "--robot-model and --walking-policy require --robot microduck"
+            )
+        return Simulation()
+    if args.robot_model is None or args.walking_policy is None:
+        raise SystemExit(
+            "--robot microduck requires --robot-model and --walking-policy"
+        )
+    from .robots.microduck import MicroDuckBackend
+
+    return Simulation(MicroDuckBackend(args.robot_model, args.walking_policy))
 
 
 def main() -> None:
     args = parse_args()
     if not 1 <= args.port <= 65535:
         raise SystemExit("--port must be between 1 and 65535")
-    server = VlnMujocoServer(default_vln_server=args.vln_server)
+    server = VlnMujocoServer(
+        default_vln_server=args.vln_server,
+        simulation=simulation_from_args(args),
+    )
     display_host = "127.0.0.1" if args.host in {"0.0.0.0", "::"} else args.host
     print(f"vln_mujoco ready: http://{display_host}:{args.port}", flush=True)
     web.run_app(server.app(), host=args.host, port=args.port, print=None)

--- a/mujoco_demo/vln_mujoco/model.py
+++ b/mujoco_demo/vln_mujoco/model.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import math
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
@@ -10,13 +9,9 @@ SCENE_NAME = "val_2"
 SCENE_ID = "procthor-val-2"
 SCENE_DATASET = "MolmoSpaces ProcTHOR 10K val"
 SPAWN = (6.5, 13.8, 0.0)
-CAMERA_NAME = "robot_rgb"
-THIRD_PERSON_CAMERA_NAME = "robot_third_person"
 CAMERA_WIDTH = 480
 CAMERA_HEIGHT = 270
 PHYSICS_DT = 0.005
-WHEEL_RADIUS = 0.033
-WHEEL_TRACK = 0.160
 
 
 def scene_path() -> Path:
@@ -46,57 +41,15 @@ def _absolute_asset_paths(root: ET.Element, source: Path) -> None:
         try:
             resolved.relative_to(asset_root)
         except ValueError as exc:
-            raise RuntimeError(f"scene asset escapes the bundled asset root: {filename}") from exc
+            raise RuntimeError(
+                f"scene asset escapes the bundled asset root: {filename}"
+            ) from exc
         if not resolved.is_file():
             raise FileNotFoundError(f"bundled scene asset is missing: {resolved}")
         element.set("file", str(resolved))
 
 
-def _robot_body() -> ET.Element:
-    body = ET.fromstring(
-        f"""
-        <body name="base_link" pos="{SPAWN[0]} {SPAWN[1]} {WHEEL_RADIUS}">
-          <freejoint name="base_joint" />
-          <inertial pos="0 0 0.055" mass="2.5" diaginertia="0.018 0.018 0.025" />
-          <geom name="base_collision" type="cylinder" size="0.092 0.028" pos="0 0 0.030"
-                rgba="0.08 0.11 0.13 1" friction="0.9 0.02 0.002" />
-          <geom name="lower_plate" type="cylinder" size="0.088 0.010" pos="0 0 0.063"
-                rgba="0.05 0.08 0.09 1" contype="0" conaffinity="0" />
-          <geom name="upper_plate" type="cylinder" size="0.078 0.010" pos="0 0 0.145"
-                rgba="0.08 0.68 0.77 1" contype="0" conaffinity="0" />
-          <geom name="mast" type="cylinder" size="0.010 0.052" pos="-0.020 0 0.105"
-                rgba="0.65 0.72 0.74 1" contype="0" conaffinity="0" />
-          <geom name="lidar" type="cylinder" size="0.042 0.018" pos="0.015 0 0.178"
-                rgba="0.05 0.08 0.09 1" contype="0" conaffinity="0" />
-          <geom name="camera_case" type="box" size="0.022 0.030 0.018" pos="0.067 0 0.162"
-                rgba="0.14 0.18 0.19 1" contype="0" conaffinity="0" />
-          <camera name="{CAMERA_NAME}" mode="fixed" pos="0.090 0 0.165"
-                  xyaxes="0 -1 0 0 0 1" fovy="79.865" />
-          <camera name="{THIRD_PERSON_CAMERA_NAME}" mode="fixed" pos="-0.65 0 0.50"
-                  xyaxes="0 -1 0 0.38 0 0.925" fovy="65" />
-          <body name="left_wheel" pos="0 0.080 0">
-            <joint name="left_wheel_joint" type="hinge" axis="0 1 0" />
-            <geom name="left_wheel_geom" type="cylinder" size="{WHEEL_RADIUS} 0.012"
-                  euler="{math.pi / 2} 0 0" mass="0.08" rgba="0.035 0.045 0.048 1"
-                  friction="2.0 0.01 0.001" solref="0.004 1" />
-          </body>
-          <body name="right_wheel" pos="0 -0.080 0">
-            <joint name="right_wheel_joint" type="hinge" axis="0 1 0" />
-            <geom name="right_wheel_geom" type="cylinder" size="{WHEEL_RADIUS} 0.012"
-                  euler="{math.pi / 2} 0 0" mass="0.08" rgba="0.035 0.045 0.048 1"
-                  friction="2.0 0.01 0.001" solref="0.004 1" />
-          </body>
-          <body name="caster" pos="-0.073 0 -0.018">
-            <geom name="caster_geom" type="sphere" size="0.015" mass="0.025"
-                  rgba="0.32 0.36 0.37 1" friction="0.05 0.001 0.0001" />
-          </body>
-        </body>
-        """
-    )
-    return body
-
-
-def build_model(source: Path | None = None) -> mujoco.MjModel:
+def load_scene_xml(source: Path | None = None) -> ET.Element:
     source = (source or scene_path()).resolve()
     if not source.is_file():
         raise FileNotFoundError(
@@ -121,10 +74,8 @@ def build_model(source: Path | None = None) -> mujoco.MjModel:
         global_visual = ET.SubElement(visual, "global")
     global_visual.set("offwidth", str(CAMERA_WIDTH))
     global_visual.set("offheight", str(CAMERA_HEIGHT))
+    return root
 
-    worldbody = root.find("worldbody")
-    if worldbody is None:
-        raise RuntimeError("MolmoSpaces scene has no worldbody")
-    worldbody.append(_robot_body())
 
+def compile_model(root: ET.Element) -> mujoco.MjModel:
     return mujoco.MjModel.from_xml_string(ET.tostring(root, encoding="unicode"))

--- a/mujoco_demo/vln_mujoco/robots/__init__.py
+++ b/mujoco_demo/vln_mujoco/robots/__init__.py
@@ -1,0 +1,1 @@
+"""Robot backends for the standalone MuJoCo demo."""

--- a/mujoco_demo/vln_mujoco/robots/base.py
+++ b/mujoco_demo/vln_mujoco/robots/base.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol, TypeAlias
+
+import mujoco
+
+Twist2D: TypeAlias = tuple[float, float]
+RobotPose: TypeAlias = tuple[float, float, float, float]
+RenderCamera: TypeAlias = str | mujoco.MjvCamera
+
+
+@dataclass(frozen=True)
+class RobotState:
+    pose: RobotPose
+    velocity: Twist2D
+    telemetry: dict[str, object] = field(default_factory=dict)
+
+
+class RobotBackend(Protocol):
+    name: str
+    camera_name: str
+    model: mujoco.MjModel
+    data: mujoco.MjData
+
+    def reset(self) -> None: ...
+
+    def step(self, command: Twist2D) -> None: ...
+
+    def state(self) -> RobotState: ...
+
+    def third_person_camera(self, camera: mujoco.MjvCamera) -> RenderCamera: ...

--- a/mujoco_demo/vln_mujoco/robots/microduck.py
+++ b/mujoco_demo/vln_mujoco/robots/microduck.py
@@ -1,0 +1,375 @@
+from __future__ import annotations
+
+import math
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Protocol
+
+import mujoco
+import numpy as np
+
+from ..model import SPAWN, load_scene_xml
+from .base import RenderCamera, RobotState, Twist2D
+
+MODEL_PREFIX = "microduck_"
+CAMERA_NAME = f"{MODEL_PREFIX}rgb"
+TRUNK_BODY_NAME = f"{MODEL_PREFIX}trunk_base"
+BASE_JOINT_NAME = f"{MODEL_PREFIX}trunk_base_freejoint"
+IMU_SENSOR_NAME = f"{MODEL_PREFIX}imu_ang_vel"
+
+CONTROL_DECIMATION = 4
+MAX_LINEAR_COMMAND = 0.30
+MIN_LINEAR_COMMAND = 0.28
+LINEAR_DEADBAND = 0.08
+MAX_ANGULAR_COMMAND = 1.50
+ANGULAR_DEADBAND = 0.03
+TORQUE_LIMIT_NM = 0.6405236195572268
+
+EXPECTED_OBSERVATION_NAMES = (
+    "base_ang_vel",
+    "projected_gravity",
+    "joint_pos",
+    "joint_vel",
+    "actions",
+    "command",
+    "head_command",
+    "body_command",
+)
+EXPECTED_COMMAND_NAMES = ("twist", "head_pose", "body_pose")
+
+
+class TensorInfo(Protocol):
+    name: str
+    shape: list[int | str | None]
+    type: str
+
+
+class ModelMetadata(Protocol):
+    custom_metadata_map: dict[str, str]
+
+
+class PolicySession(Protocol):
+    def get_inputs(self) -> list[TensorInfo]: ...
+
+    def get_outputs(self) -> list[TensorInfo]: ...
+
+    def get_modelmeta(self) -> ModelMetadata: ...
+
+    def run(
+        self,
+        output_names: list[str],
+        input_feed: dict[str, np.ndarray],
+    ) -> list[np.ndarray]: ...
+
+
+def _load_policy_session(policy_path: Path) -> PolicySession:
+    try:
+        import onnxruntime as ort
+    except ImportError as exc:
+        raise RuntimeError(
+            "MicroDuck requires the optional dependency: "
+            "uv sync --extra microduck"
+        ) from exc
+    return ort.InferenceSession(
+        str(policy_path.resolve()),
+        providers=["CPUExecutionProvider"],
+    )
+
+
+def _metadata_names(metadata: dict[str, str], key: str) -> tuple[str, ...]:
+    value = metadata.get(key, "")
+    names = tuple(part.strip() for part in value.split(",") if part.strip())
+    if not names:
+        raise ValueError(f"MicroDuck walking policy is missing {key!r} metadata")
+    return names
+
+
+def _metadata_floats(metadata: dict[str, str], key: str) -> np.ndarray:
+    value = metadata.get(key, "")
+    try:
+        values = np.asarray(
+            [float(part.strip()) for part in value.split(",") if part.strip()],
+            dtype=np.float32,
+        )
+    except ValueError as exc:
+        raise ValueError(f"MicroDuck walking policy has invalid {key!r} metadata") from exc
+    if values.size == 0 or not np.isfinite(values).all():
+        raise ValueError(f"MicroDuck walking policy has invalid {key!r} metadata")
+    return values
+
+
+def shape_microduck_command(linear: float, angular: float) -> Twist2D:
+    if not math.isfinite(linear) or not math.isfinite(angular):
+        return (0.0, 0.0)
+    linear = float(np.clip(linear, -MAX_LINEAR_COMMAND, MAX_LINEAR_COMMAND))
+    angular = float(np.clip(angular, -MAX_ANGULAR_COMMAND, MAX_ANGULAR_COMMAND))
+    if abs(linear) < LINEAR_DEADBAND:
+        linear = 0.0
+    elif abs(linear) < MIN_LINEAR_COMMAND:
+        linear = math.copysign(MIN_LINEAR_COMMAND, linear)
+    if abs(angular) < ANGULAR_DEADBAND:
+        angular = 0.0
+    return linear, angular
+
+
+def _quat_rotate_inverse(quaternion: np.ndarray, vector: np.ndarray) -> np.ndarray:
+    scalar = quaternion[0]
+    xyz = quaternion[1:4]
+    cross = np.cross(xyz, vector) * 2.0
+    return vector - scalar * cross + np.cross(xyz, cross)
+
+
+def build_model(
+    robot_source: Path,
+    scene_source: Path | None = None,
+) -> mujoco.MjModel:
+    robot_source = robot_source.resolve()
+    if not robot_source.is_file():
+        raise FileNotFoundError(f"MicroDuck MJCF is missing: {robot_source}")
+
+    scene_xml = ET.tostring(load_scene_xml(scene_source), encoding="unicode")
+    scene = mujoco.MjSpec.from_string(scene_xml)
+    robot = mujoco.MjSpec.from_file(str(robot_source))
+    trunk = robot.body("trunk_base")
+    camera = robot.camera("head_camera")
+    if trunk is None or camera is None:
+        raise ValueError("MicroDuck MJCF requires trunk_base and head_camera")
+
+    trunk.pos = [SPAWN[0], SPAWN[1], 0.125]
+    camera.name = "rgb"
+    camera.fovy = 79.865
+    camera.quat = [0.70710678, 0.0, 0.0, -0.70710678]
+
+    anchor = scene.worldbody.add_frame()
+    scene.attach(robot, prefix=MODEL_PREFIX, frame=anchor)
+    return scene.compile()
+
+
+class MicroDuckPolicy:
+    def __init__(
+        self,
+        model: mujoco.MjModel,
+        data: mujoco.MjData,
+        policy_path: Path,
+        session: PolicySession | None = None,
+    ) -> None:
+        policy_path = policy_path.resolve()
+        if session is None and not policy_path.is_file():
+            raise FileNotFoundError(f"MicroDuck walking policy is missing: {policy_path}")
+        self.model = model
+        self.data = data
+        self.session = session or _load_policy_session(policy_path)
+
+        inputs = self.session.get_inputs()
+        outputs = self.session.get_outputs()
+        if len(inputs) != 1 or inputs[0].shape != [1, 61]:
+            raise ValueError("MicroDuck walking policy must accept [1, 61] observations")
+        if inputs[0].type != "tensor(float)":
+            raise ValueError("MicroDuck walking policy input must be float32")
+        if len(outputs) != 1 or outputs[0].shape != [1, 14]:
+            raise ValueError("MicroDuck walking policy must return [1, 14] actions")
+        if outputs[0].type != "tensor(float)":
+            raise ValueError("MicroDuck walking policy output must be float32")
+        self.input_name = inputs[0].name
+        self.output_name = outputs[0].name
+
+        metadata = self.session.get_modelmeta().custom_metadata_map
+        joint_names = _metadata_names(metadata, "joint_names")
+        observation_names = _metadata_names(metadata, "observation_names")
+        command_names = _metadata_names(metadata, "command_names")
+        if observation_names != EXPECTED_OBSERVATION_NAMES:
+            raise ValueError("MicroDuck walking policy observation layout is unsupported")
+        if command_names != EXPECTED_COMMAND_NAMES:
+            raise ValueError("MicroDuck walking policy command layout is unsupported")
+
+        self.default_pose = _metadata_floats(metadata, "default_joint_pos")
+        if self.default_pose.shape != (14,):
+            raise ValueError("MicroDuck walking policy must define 14 default joints")
+        try:
+            self.action_scale = float(metadata["action_scale"])
+        except (KeyError, ValueError) as exc:
+            raise ValueError(
+                "MicroDuck walking policy has invalid 'action_scale' metadata"
+            ) from exc
+        if not math.isfinite(self.action_scale) or self.action_scale <= 0.0:
+            raise ValueError(
+                "MicroDuck walking policy has invalid 'action_scale' metadata"
+            )
+
+        actuator_joint_names: list[str] = []
+        joint_qpos: list[int] = []
+        joint_qvel: list[int] = []
+        for index in range(model.nu):
+            joint_id = int(model.actuator_trnid[index, 0])
+            if joint_id < 0:
+                raise ValueError("MicroDuck actuators must target joints")
+            model_name = model.joint(joint_id).name
+            if not model_name.startswith(MODEL_PREFIX):
+                raise ValueError("MicroDuck actuator joint is missing its model prefix")
+            actuator_joint_names.append(model_name.removeprefix(MODEL_PREFIX))
+            joint_qpos.append(int(model.jnt_qposadr[joint_id]))
+            joint_qvel.append(int(model.jnt_dofadr[joint_id]))
+        if tuple(actuator_joint_names) != joint_names:
+            raise ValueError(
+                "MicroDuck policy joint_names do not match the MJCF actuator order"
+            )
+        self.joint_qpos = np.asarray(joint_qpos)
+        self.joint_qvel = np.asarray(joint_qvel)
+
+        self.trunk_body = model.body(TRUNK_BODY_NAME).id
+        self.imu_sensor = model.sensor(IMU_SENSOR_NAME).id
+        if int(model.sensor_dim[self.imu_sensor]) != 3:
+            raise ValueError("MicroDuck IMU angular-velocity sensor must have 3 values")
+        self.last_action = np.zeros(14, dtype=np.float32)
+        self.command = np.zeros(13, dtype=np.float32)
+
+    def reset(self) -> None:
+        self.last_action.fill(0.0)
+        self.command.fill(0.0)
+
+    def set_velocity(self, linear: float, angular: float) -> Twist2D:
+        linear, angular = shape_microduck_command(linear, angular)
+        self.command.fill(0.0)
+        self.command[0] = linear
+        self.command[2] = angular
+        return linear, angular
+
+    def observation(self) -> np.ndarray:
+        sensor_address = int(self.model.sensor_adr[self.imu_sensor])
+        angular_velocity = self.data.sensordata[
+            sensor_address : sensor_address + 3
+        ].astype(np.float32)
+        quaternion = self.data.xquat[self.trunk_body].astype(np.float32)
+        gravity = _quat_rotate_inverse(
+            quaternion,
+            np.array([0.0, 0.0, -1.0], dtype=np.float32),
+        )
+        joint_position = self.data.qpos[self.joint_qpos].astype(np.float32)
+        joint_velocity = self.data.qvel[self.joint_qvel].astype(np.float32)
+        observation = np.concatenate(
+            (
+                angular_velocity,
+                gravity,
+                joint_position - self.default_pose,
+                joint_velocity,
+                self.last_action,
+                self.command,
+            )
+        ).astype(np.float32)
+        if observation.shape != (61,) or not np.isfinite(observation).all():
+            raise RuntimeError("MicroDuck policy observation is invalid")
+        return observation
+
+    def step(self) -> None:
+        outputs = self.session.run(
+            [self.output_name],
+            {self.input_name: self.observation().reshape(1, 61)},
+        )
+        action = np.asarray(outputs[0], dtype=np.float32)
+        if action.shape != (1, 14) or not np.isfinite(action).all():
+            raise RuntimeError("MicroDuck walking policy returned invalid actions")
+        self.last_action[:] = action[0]
+        self.data.ctrl[:] = self.default_pose + self.last_action * self.action_scale
+
+
+class MicroDuckBackend:
+    name = "MicroDuck"
+    camera_name = CAMERA_NAME
+
+    def __init__(
+        self,
+        robot_model: Path,
+        walking_policy: Path,
+        policy_session: PolicySession | None = None,
+        scene_source: Path | None = None,
+    ) -> None:
+        self.model = build_model(robot_model, scene_source)
+        if self.model.nu != 14:
+            raise ValueError("MicroDuck MJCF must define 14 actuators")
+        self.model.actuator_forcerange[:, 0] = -TORQUE_LIMIT_NM
+        self.model.actuator_forcerange[:, 1] = TORQUE_LIMIT_NM
+        self.model.actuator_forcelimited[:] = 1
+        self.data = mujoco.MjData(self.model)
+        self.policy = MicroDuckPolicy(
+            self.model,
+            self.data,
+            walking_policy,
+            session=policy_session,
+        )
+        self._base_joint = self.model.joint(BASE_JOINT_NAME).id
+        self._base_qpos = int(self.model.jnt_qposadr[self._base_joint])
+        self._base_dof = int(self.model.jnt_dofadr[self._base_joint])
+        self._policy_command = (0.0, 0.0)
+        self._physics_steps = 0
+        self._initialize_pose()
+
+    def _initialize_pose(self) -> None:
+        self.data.qpos[self._base_qpos : self._base_qpos + 3] = [
+            SPAWN[0],
+            SPAWN[1],
+            0.125,
+        ]
+        self.data.qpos[self._base_qpos + 3 : self._base_qpos + 7] = [
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+        ]
+        self.data.qpos[self.policy.joint_qpos] = self.policy.default_pose
+        self.data.ctrl[:] = self.policy.default_pose
+        mujoco.mj_forward(self.model, self.data)
+
+    def reset(self) -> None:
+        mujoco.mj_resetData(self.model, self.data)
+        self.policy.reset()
+        self._policy_command = (0.0, 0.0)
+        self._physics_steps = 0
+        self._initialize_pose()
+
+    def step(self, command: Twist2D) -> None:
+        if self._physics_steps % CONTROL_DECIMATION == 0:
+            self._policy_command = self.policy.set_velocity(*command)
+            self.policy.step()
+        mujoco.mj_step(self.model, self.data)
+        self._physics_steps += 1
+
+    @staticmethod
+    def _yaw(quaternion: np.ndarray) -> float:
+        qw, qx, qy, qz = (float(value) for value in quaternion)
+        return math.atan2(
+            2.0 * (qw * qz + qx * qy),
+            1.0 - 2.0 * (qy * qy + qz * qz),
+        )
+
+    def state(self) -> RobotState:
+        qpos = self.data.qpos
+        x = float(qpos[self._base_qpos])
+        y = float(qpos[self._base_qpos + 1])
+        z = float(qpos[self._base_qpos + 2])
+        quaternion = qpos[self._base_qpos + 3 : self._base_qpos + 7].astype(
+            np.float32
+        )
+        yaw = self._yaw(quaternion)
+        velocity_world = self.data.qvel[
+            self._base_dof : self._base_dof + 3
+        ].astype(np.float32)
+        velocity_body = _quat_rotate_inverse(quaternion, velocity_world)
+        angular = float(self.data.qvel[self._base_dof + 5])
+        return RobotState(
+            pose=(x, y, z, yaw),
+            velocity=(float(velocity_body[0]), angular),
+            telemetry={
+                "policy_command": {
+                    "linear": self._policy_command[0],
+                    "angular": self._policy_command[1],
+                }
+            },
+        )
+
+    def third_person_camera(self, camera: mujoco.MjvCamera) -> RenderCamera:
+        camera.type = mujoco.mjtCamera.mjCAMERA_FREE
+        camera.distance = 0.55
+        camera.azimuth = 135.0
+        camera.elevation = -20.0
+        camera.lookat[:] = self.data.xpos[self.policy.trunk_body]
+        return camera

--- a/mujoco_demo/vln_mujoco/robots/turtlebot.py
+++ b/mujoco_demo/vln_mujoco/robots/turtlebot.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import math
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import mujoco
+
+from ..model import PHYSICS_DT, SPAWN, compile_model, load_scene_xml
+from .base import RenderCamera, RobotState, Twist2D
+
+CAMERA_NAME = "robot_rgb"
+THIRD_PERSON_CAMERA_NAME = "robot_third_person"
+WHEEL_RADIUS = 0.033
+WHEEL_TRACK = 0.160
+
+
+def _robot_body() -> ET.Element:
+    return ET.fromstring(
+        f"""
+        <body name="base_link" pos="{SPAWN[0]} {SPAWN[1]} {WHEEL_RADIUS}">
+          <freejoint name="base_joint" />
+          <inertial pos="0 0 0.055" mass="2.5" diaginertia="0.018 0.018 0.025" />
+          <geom name="base_collision" type="cylinder" size="0.092 0.028" pos="0 0 0.030"
+                rgba="0.08 0.11 0.13 1" friction="0.9 0.02 0.002" />
+          <geom name="lower_plate" type="cylinder" size="0.088 0.010" pos="0 0 0.063"
+                rgba="0.05 0.08 0.09 1" contype="0" conaffinity="0" />
+          <geom name="upper_plate" type="cylinder" size="0.078 0.010" pos="0 0 0.145"
+                rgba="0.08 0.68 0.77 1" contype="0" conaffinity="0" />
+          <geom name="mast" type="cylinder" size="0.010 0.052" pos="-0.020 0 0.105"
+                rgba="0.65 0.72 0.74 1" contype="0" conaffinity="0" />
+          <geom name="lidar" type="cylinder" size="0.042 0.018" pos="0.015 0 0.178"
+                rgba="0.05 0.08 0.09 1" contype="0" conaffinity="0" />
+          <geom name="camera_case" type="box" size="0.022 0.030 0.018" pos="0.067 0 0.162"
+                rgba="0.14 0.18 0.19 1" contype="0" conaffinity="0" />
+          <camera name="{CAMERA_NAME}" mode="fixed" pos="0.090 0 0.165"
+                  xyaxes="0 -1 0 0 0 1" fovy="79.865" />
+          <camera name="{THIRD_PERSON_CAMERA_NAME}" mode="fixed" pos="-0.65 0 0.50"
+                  xyaxes="0 -1 0 0.38 0 0.925" fovy="65" />
+          <body name="left_wheel" pos="0 0.080 0">
+            <joint name="left_wheel_joint" type="hinge" axis="0 1 0" />
+            <geom name="left_wheel_geom" type="cylinder" size="{WHEEL_RADIUS} 0.012"
+                  euler="{math.pi / 2} 0 0" mass="0.08" rgba="0.035 0.045 0.048 1"
+                  friction="2.0 0.01 0.001" solref="0.004 1" />
+          </body>
+          <body name="right_wheel" pos="0 -0.080 0">
+            <joint name="right_wheel_joint" type="hinge" axis="0 1 0" />
+            <geom name="right_wheel_geom" type="cylinder" size="{WHEEL_RADIUS} 0.012"
+                  euler="{math.pi / 2} 0 0" mass="0.08" rgba="0.035 0.045 0.048 1"
+                  friction="2.0 0.01 0.001" solref="0.004 1" />
+          </body>
+          <body name="caster" pos="-0.073 0 -0.018">
+            <geom name="caster_geom" type="sphere" size="0.015" mass="0.025"
+                  rgba="0.32 0.36 0.37 1" friction="0.05 0.001 0.0001" />
+          </body>
+        </body>
+        """
+    )
+
+
+def build_model(source: Path | None = None) -> mujoco.MjModel:
+    root = load_scene_xml(source)
+    worldbody = root.find("worldbody")
+    if worldbody is None:
+        raise RuntimeError("MolmoSpaces scene has no worldbody")
+    worldbody.append(_robot_body())
+    return compile_model(root)
+
+
+class TurtleBotBackend:
+    name = "TurtleBot"
+    camera_name = CAMERA_NAME
+
+    def __init__(self, source: Path | None = None) -> None:
+        self.model = build_model(source)
+        self.data = mujoco.MjData(self.model)
+        self._left_joint = self.model.joint("left_wheel_joint").id
+        self._right_joint = self.model.joint("right_wheel_joint").id
+        self._base_joint = self.model.joint("base_joint").id
+        self._base_qpos = self.model.jnt_qposadr[self._base_joint]
+        self._base_dof = self.model.jnt_dofadr[self._base_joint]
+        self._left_qpos = self.model.jnt_qposadr[self._left_joint]
+        self._right_qpos = self.model.jnt_qposadr[self._right_joint]
+        self._left_dof = self.model.jnt_dofadr[self._left_joint]
+        self._right_dof = self.model.jnt_dofadr[self._right_joint]
+        self._yaw = 0.0
+        mujoco.mj_forward(self.model, self.data)
+
+    def reset(self) -> None:
+        mujoco.mj_resetData(self.model, self.data)
+        self._yaw = 0.0
+        mujoco.mj_forward(self.model, self.data)
+
+    def step(self, command: Twist2D) -> None:
+        linear, angular = command
+        previous_yaw = self._yaw
+        self._yaw = math.atan2(
+            math.sin(previous_yaw + angular * PHYSICS_DT),
+            math.cos(previous_yaw + angular * PHYSICS_DT),
+        )
+        heading = previous_yaw + angular * PHYSICS_DT / 2.0
+        self.data.qpos[self._base_qpos] += linear * math.cos(heading) * PHYSICS_DT
+        self.data.qpos[self._base_qpos + 1] += linear * math.sin(heading) * PHYSICS_DT
+        self.data.qpos[self._base_qpos + 3 : self._base_qpos + 7] = (
+            math.cos(self._yaw / 2.0),
+            0.0,
+            0.0,
+            math.sin(self._yaw / 2.0),
+        )
+
+        left = (linear - angular * WHEEL_TRACK / 2.0) / WHEEL_RADIUS
+        right = (linear + angular * WHEEL_TRACK / 2.0) / WHEEL_RADIUS
+        self.data.qpos[self._left_qpos] += left * PHYSICS_DT
+        self.data.qpos[self._right_qpos] += right * PHYSICS_DT
+        self.data.qvel.fill(0.0)
+        self.data.qvel[self._base_dof] = linear * math.cos(self._yaw)
+        self.data.qvel[self._base_dof + 1] = linear * math.sin(self._yaw)
+        self.data.qvel[self._base_dof + 5] = angular
+        self.data.qvel[self._left_dof] = left
+        self.data.qvel[self._right_dof] = right
+        self.data.time += PHYSICS_DT
+        mujoco.mj_forward(self.model, self.data)
+
+    def state(self) -> RobotState:
+        qpos = self.data.qpos
+        x, y, z = (
+            float(value)
+            for value in qpos[self._base_qpos : self._base_qpos + 3]
+        )
+        qw, qx, qy, qz = (
+            float(value)
+            for value in qpos[self._base_qpos + 3 : self._base_qpos + 7]
+        )
+        yaw = math.atan2(
+            2.0 * (qw * qz + qx * qy),
+            1.0 - 2.0 * (qy * qy + qz * qz),
+        )
+        left = float(self.data.qvel[self._left_dof])
+        right = float(self.data.qvel[self._right_dof])
+        linear = WHEEL_RADIUS * (left + right) / 2.0
+        angular = WHEEL_RADIUS * (right - left) / WHEEL_TRACK
+        return RobotState((x, y, z, yaw), (linear, angular))
+
+    def third_person_camera(self, _camera: mujoco.MjvCamera) -> RenderCamera:
+        return THIRD_PERSON_CAMERA_NAME

--- a/mujoco_demo/vln_mujoco/server.py
+++ b/mujoco_demo/vln_mujoco/server.py
@@ -10,6 +10,7 @@ from urllib.parse import urlparse
 
 from aiohttp import WSMsgType, web
 
+from .model import SCENE_DATASET, SCENE_ID, SCENE_NAME
 from .mpc import (
     A_MAX_V,
     A_MAX_W,
@@ -22,11 +23,10 @@ from .mpc import (
     Q_WEIGHTS,
     R_WEIGHTS,
     TRACK_V_MAX,
-    WAYPOINT_DT_S,
     W_MAX,
+    WAYPOINT_DT_S,
     MpcTracker,
 )
-from .model import SCENE_DATASET, SCENE_ID, SCENE_NAME
 from .simulation import Simulation
 from .vln_client import VlnClient
 
@@ -254,7 +254,7 @@ class VlnMujocoServer:
         )
         return {
             "scene": {"id": SCENE_ID, "name": SCENE_NAME, "dataset": SCENE_DATASET},
-            "robot": {"name": "TurtleBot", "connected": True},
+            "robot": {"name": self.simulation.robot_name, "connected": True},
             "simulation": self.simulation.snapshot(),
             "vln": {
                 "state": vln.state,

--- a/mujoco_demo/vln_mujoco/simulation.py
+++ b/mujoco_demo/vln_mujoco/simulation.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import io
-import math
 import threading
 import time
 from dataclasses import dataclass
@@ -10,17 +9,13 @@ import mujoco
 import numpy as np
 from PIL import Image
 
+from .model import CAMERA_HEIGHT, CAMERA_WIDTH, PHYSICS_DT
 from .mpc import TRACK_V_MAX, W_MAX
-from .model import (
-    CAMERA_HEIGHT,
-    CAMERA_NAME,
-    CAMERA_WIDTH,
-    PHYSICS_DT,
-    THIRD_PERSON_CAMERA_NAME,
-    WHEEL_RADIUS,
-    WHEEL_TRACK,
-    build_model,
-)
+from .robots.base import RobotBackend
+from .robots.turtlebot import TurtleBotBackend
+
+COMMAND_TIMEOUT_S = 0.35
+FRAME_PERIOD_S = 0.05
 
 
 @dataclass(frozen=True)
@@ -32,19 +27,10 @@ class CameraFrame:
 
 
 class Simulation:
-    def __init__(self) -> None:
-        self.model = build_model()
-        self.data = mujoco.MjData(self.model)
-        self._left_joint = self.model.joint("left_wheel_joint").id
-        self._right_joint = self.model.joint("right_wheel_joint").id
-        self._base_joint = self.model.joint("base_joint").id
-        self._base_qpos = self.model.jnt_qposadr[self._base_joint]
-        self._base_dof = self.model.jnt_dofadr[self._base_joint]
-        self._left_qpos = self.model.jnt_qposadr[self._left_joint]
-        self._right_qpos = self.model.jnt_qposadr[self._right_joint]
-        self._left_dof = self.model.jnt_dofadr[self._left_joint]
-        self._right_dof = self.model.jnt_dofadr[self._right_joint]
-        self._yaw = 0.0
+    def __init__(self, robot: RobotBackend | None = None) -> None:
+        self.robot = robot or TurtleBotBackend()
+        self.model = self.robot.model
+        self.data = self.robot.data
         self._lock = threading.RLock()
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
@@ -54,7 +40,10 @@ class Simulation:
         self._third_person_frame: CameraFrame | None = None
         self._frame_count = 0
         self._started_at = time.monotonic()
-        mujoco.mj_forward(self.model, self.data)
+
+    @property
+    def robot_name(self) -> str:
+        return self.robot.name
 
     def start(self) -> None:
         if self._thread is not None:
@@ -72,11 +61,9 @@ class Simulation:
 
     def reset(self) -> None:
         with self._lock:
-            mujoco.mj_resetData(self.model, self.data)
+            self.robot.reset()
             self._command = (0.0, 0.0)
             self._command_at = 0.0
-            self._yaw = 0.0
-            mujoco.mj_forward(self.model, self.data)
 
     def set_velocity(self, linear: float, angular: float) -> None:
         # Physical sanity bound only; per-mode VLN limits live in the MPC.
@@ -106,24 +93,13 @@ class Simulation:
 
     def snapshot(self) -> dict[str, object]:
         with self._lock:
-            qpos = self.data.qpos
-            x, y, z = (float(value) for value in qpos[self._base_qpos : self._base_qpos + 3])
-            qw, qx, qy, qz = (
-                float(value)
-                for value in qpos[self._base_qpos + 3 : self._base_qpos + 7]
-            )
-            yaw = math.atan2(
-                2.0 * (qw * qz + qx * qy),
-                1.0 - 2.0 * (qy * qy + qz * qz),
-            )
-            left = float(self.data.qvel[self._left_dof])
-            right = float(self.data.qvel[self._right_dof])
-            linear = WHEEL_RADIUS * (left + right) / 2.0
-            angular = WHEEL_RADIUS * (right - left) / WHEEL_TRACK
+            state = self.robot.state()
+            x, y, z, yaw = state.pose
+            linear, angular = state.velocity
             command = self._command
             frame = self._frame
             elapsed = max(time.monotonic() - self._started_at, 1e-6)
-            return {
+            snapshot = {
                 "pose": {"x": x, "y": y, "z": z, "yaw": yaw},
                 "velocity": {"linear": linear, "angular": angular},
                 "command": {"linear": command[0], "angular": command[1]},
@@ -134,43 +110,25 @@ class Simulation:
                     "fps": self._frame_count / elapsed,
                 },
             }
+            if state.telemetry:
+                snapshot["backend"] = state.telemetry
+            return snapshot
 
-    def _advance_kinematics(self, now: float) -> None:
-        linear, angular = self._command
-        if self._command_at and now - self._command_at > 0.35:
-            linear, angular = 0.0, 0.0
-            self._command = (0.0, 0.0)
-
-        previous_yaw = self._yaw
-        self._yaw = math.atan2(
-            math.sin(previous_yaw + angular * PHYSICS_DT),
-            math.cos(previous_yaw + angular * PHYSICS_DT),
-        )
-        heading = previous_yaw + angular * PHYSICS_DT / 2.0
-        self.data.qpos[self._base_qpos] += linear * math.cos(heading) * PHYSICS_DT
-        self.data.qpos[self._base_qpos + 1] += linear * math.sin(heading) * PHYSICS_DT
-        self.data.qpos[self._base_qpos + 3 : self._base_qpos + 7] = (
-            math.cos(self._yaw / 2.0),
-            0.0,
-            0.0,
-            math.sin(self._yaw / 2.0),
-        )
-
-        left = (linear - angular * WHEEL_TRACK / 2.0) / WHEEL_RADIUS
-        right = (linear + angular * WHEEL_TRACK / 2.0) / WHEEL_RADIUS
-        self.data.qpos[self._left_qpos] += left * PHYSICS_DT
-        self.data.qpos[self._right_qpos] += right * PHYSICS_DT
-        self.data.qvel.fill(0.0)
-        self.data.qvel[self._base_dof] = linear * math.cos(self._yaw)
-        self.data.qvel[self._base_dof + 1] = linear * math.sin(self._yaw)
-        self.data.qvel[self._base_dof + 5] = angular
-        self.data.qvel[self._left_dof] = left
-        self.data.qvel[self._right_dof] = right
-        self.data.time += PHYSICS_DT
-        mujoco.mj_forward(self.model, self.data)
+    def _advance(self, now: float) -> None:
+        command = self._command
+        if self._command_at and now - self._command_at > COMMAND_TIMEOUT_S:
+            command = (0.0, 0.0)
+            self._command = command
+        self.robot.step(command)
 
     def _run(self) -> None:
-        renderer = mujoco.Renderer(self.model, height=CAMERA_HEIGHT, width=CAMERA_WIDTH)
+        renderer = mujoco.Renderer(
+            self.model,
+            height=CAMERA_HEIGHT,
+            width=CAMERA_WIDTH,
+        )
+        third_person_camera = mujoco.MjvCamera()
+        mujoco.mjv_defaultCamera(third_person_camera)
         next_step = time.monotonic()
         next_frame = next_step
         try:
@@ -180,32 +138,37 @@ class Simulation:
                     time.sleep(min(next_step - now, 0.002))
                     continue
                 with self._lock:
-                    self._advance_kinematics(now)
+                    self._advance(now)
                 next_step += PHYSICS_DT
                 if now - next_step > 0.25:
                     next_step = now
                 if now >= next_frame:
                     with self._lock:
-                        renderer.update_scene(self.data, camera=CAMERA_NAME)
+                        renderer.update_scene(
+                            self.data,
+                            camera=self.robot.camera_name,
+                        )
                         rgb = np.asarray(renderer.render(), dtype=np.uint8).copy()
-                        renderer.update_scene(self.data, camera=THIRD_PERSON_CAMERA_NAME)
+                        render_camera = self.robot.third_person_camera(
+                            third_person_camera
+                        )
+                        renderer.update_scene(self.data, camera=render_camera)
                         third_person_rgb = np.asarray(
                             renderer.render(), dtype=np.uint8
                         ).copy()
-                        capture_pose = (
-                            float(self.data.qpos[self._base_qpos]),
-                            float(self.data.qpos[self._base_qpos + 1]),
-                            self._yaw,
-                        )
+                        x, y, _, yaw = self.robot.state().pose
+                        capture_pose = (x, y, yaw)
                     stamp_ns = time.time_ns()
                     frame = self._encode_frame(stamp_ns, rgb, capture_pose)
                     third_person_frame = self._encode_frame(
-                        stamp_ns, third_person_rgb, capture_pose
+                        stamp_ns,
+                        third_person_rgb,
+                        capture_pose,
                     )
                     with self._lock:
                         self._frame = frame
                         self._third_person_frame = third_person_frame
                         self._frame_count += 1
-                    next_frame = now + 0.05
+                    next_frame = now + FRAME_PERIOD_S
         finally:
             renderer.close()


### PR DESCRIPTION
## Dependency

Draft stacked on #3. Please review/merge #3 first. After #3 lands, this branch will be rebased onto `main`, removing the backend-refactor commits from this PR's diff.

## Summary

- add an optional `MicroDuckBackend` implementing the shared MuJoCo robot contract
- compose the external MicroDuck MJCF into the bundled ProcTHOR scene with `MjSpec.attach` and a `microduck_` namespace
- run the 61D-to-14D walking policy through lazily imported ONNX Runtime
- validate ONNX input/output shape, dtype, metadata, actuator order, and finite observations/actions at startup/runtime
- expose `--robot`, `--robot-model`, and `--walking-policy` CLI options
- keep ONNX Runtime behind the `microduck` optional dependency; default TurtleBot installs remain unchanged
- document the external asset boundary, policy contract, command shaping, and CLI parameters

No MicroDuck MJCF, mesh, ONNX, video, or generated asset is committed to this repository.

## Testing

- Ruff on changed Python files
- `uv run --extra dev pytest -q` — 26 passed without ONNX Runtime
- `uv run --extra microduck --extra dev pytest -q` — 26 passed
- clean `UV_PROJECT_ENVIRONMENT` confirmed the default TurtleBot path neither installs nor imports `onnxruntime`
- real MJCF + real ONNX + EGL smoke test: 0.425 m movement in 4 s, valid first/third-person JPEG frames
- end-to-end LightNav test against the live VLN service: connected, 11 inference steps, 10-waypoint results, MPC command generation, RL gait command, and measured MicroDuck displacement
